### PR TITLE
ci: add debug APK artifact upload to test-android job

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -101,6 +101,25 @@ jobs:
         with:
           name: reports
           path: app/build/reports/
+  build-apk:
+    timeout-minutes: 10
+    name: Build Android APK
+    needs: test-android
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+      - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - run: devbox run ./gradlew assembleDebug
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -128,6 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       # keep-sorted start
+      - build-apk
       - check-actions
       - check-format
       - check-renovate


### PR DESCRIPTION
Generate and upload debug APK as GitHub Actions artifact on every
PR and main branch push. APKs are retained for 7 days and named with
commit SHA for traceability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated Android APK build and artifact storage capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->