### PR TITLE
ci: enable ci cache

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -58,6 +58,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+        with:
+          enable-cache: true
       - run: devbox run actionlint
       - run: devbox run ghalint run
       - run: devbox run zizmor .github/
@@ -73,6 +75,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+        with:
+          enable-cache: true
       - run: devbox run fmt
       - run: git diff
   test-android:
@@ -89,6 +93,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+        with:
+          enable-cache: true
       - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ~/.gradle/caches
@@ -114,6 +120,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+        with:
+          enable-cache: true
       - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ~/.gradle/caches
@@ -140,6 +148,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0
+        with:
+          enable-cache: true
       - run: devbox run renovate-config-validator --strict
   status-check:
     timeout-minutes: 5


### PR DESCRIPTION
This pull request updates the `.github/workflows/check.yaml` workflow to improve build performance by enabling caching for the Devbox install step across several jobs. The main change is the addition of the `enable-cache: true` option to the `jetify-com/devbox-install-action`, which should speed up workflow runs by reusing previously installed dependencies.

**Workflow performance improvements:**

* Added `enable-cache: true` to the `jetify-com/devbox-install-action` step in the following jobs to enable caching of Devbox dependencies:
  * `jobs:`
    * Main check job
    * Formatting check job
    * Android test job [[1]](diffhunk://#diff-78ef9dc8d6ce0002e26fc4adde9d00123acd7a7c214da456a828814850c7d9e2R96-R97) [[2]](diffhunk://#diff-78ef9dc8d6ce0002e26fc4adde9d00123acd7a7c214da456a828814850c7d9e2R123-R124)
    * Renovate config validation job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline performance by enabling caching for dependency installation steps across multiple CI jobs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->