### PR TITLE
ci: enable path-filter

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,6 @@ jobs:
       # keep-sorted start
       actions: ${{steps.changes.outputs.actions}}
       android: ${{steps.changes.outputs.android}}
-      devbox: ${{steps.changes.outputs.devbox}}
       renovate: ${{steps.changes.outputs.renovate}}
       # keep-sorted end
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an active path-filter gate to run CI jobs only when relevant files change, reducing unnecessary runs.
  * Converted CI jobs to conditional execution based on path-filter outputs for actions, android, and renovate.
  * Introduced a consolidated status-check job that aggregates critical job outcomes and fails on upstream failures.
  * Expanded CI validation steps with explicit checkout and additional linting/validation to improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->