### PR TITLE
refactor: use collectAsStateWithLifecycle for lifecycle-aware state collection

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -13,10 +13,10 @@ import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -82,8 +82,8 @@ fun PinosuApp(viewModel: LoginViewModel, nip55SignerClient: Nip55SignerClient) {
   val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
   val scope = rememberCoroutineScope()
 
-  val mainUiState by viewModel.mainUiState.collectAsState()
-  val loginUiState by viewModel.uiState.collectAsState()
+  val mainUiState by viewModel.mainUiState.collectAsStateWithLifecycle()
+  val loginUiState by viewModel.uiState.collectAsStateWithLifecycle()
 
   val nip55Launcher =
       rememberLauncherForActivityResult(
@@ -177,7 +177,7 @@ fun PinosuApp(viewModel: LoginViewModel, nip55SignerClient: Nip55SignerClient) {
               popEnterTransition = { defaultPopEnterTransition },
               popExitTransition = { defaultPopExitTransition }) {
                 val bookmarkViewModel: BookmarkViewModel = hiltViewModel()
-                val bookmarkUiState by bookmarkViewModel.uiState.collectAsState()
+                val bookmarkUiState by bookmarkViewModel.uiState.collectAsStateWithLifecycle()
 
                 LaunchedEffect(mainUiState.userPubkey) {
                   if (mainUiState.userPubkey == null) {


### PR DESCRIPTION
Replace collectAsState() with collectAsStateWithLifecycle() in MainActivity
to automatically stop Flow collection when the app is in the background,
reducing unnecessary resource consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized app state management to reduce unnecessary UI updates when the app is backgrounded, improving overall performance and battery efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->