### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,6 @@ dependencies {
   implementation(libs.androidx.compose.material.icons.extended)
   debugImplementation(libs.androidx.compose.ui.tooling)
   debugImplementation(libs.androidx.compose.ui.test.manifest)
-  androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 
   implementation(libs.androidx.lifecycle.runtime.ktx)
   implementation(libs.androidx.lifecycle.viewmodel.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ androidx-compose-material3 = {group = "androidx.compose.material3", name = "mate
 androidx-compose-material-icons-extended = {group = "androidx.compose.material", name = "material-icons-extended"}
 androidx-compose-ui-tooling = {group = "androidx.compose.ui", name = "ui-tooling"}
 androidx-compose-ui-test-manifest = {group = "androidx.compose.ui", name = "ui-test-manifest"}
-androidx-compose-ui-test-junit4 = {group = "androidx.compose.ui", name = "ui-test-junit4"}
 androidx-lifecycle-runtime-ktx = {group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle"}
 androidx-lifecycle-viewmodel-ktx = {group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle"}
 androidx-lifecycle-runtime-compose = {group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle"}


### PR DESCRIPTION
This pull request removes several dependencies related to legacy Android support libraries and UI testing from the project. The main focus is on cleaning up unused or unnecessary dependencies in both the Gradle build script and the version catalog.

Dependency cleanup:

* Removed `androidx.appcompat` and `androidx-espresso-core` dependencies from both `app/build.gradle.kts` and `gradle/libs.versions.toml`, as well as their corresponding version references. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L50) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L95) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL5-L6) [[4]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL51-L52)
* Removed `androidx.compose.ui.test.junit4` dependency from `app/build.gradle.kts` and its reference from `gradle/libs.versions.toml`. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L62) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL18)

These changes help streamline the project's dependencies, reducing potential build complexity and minimizing unused code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused runtime and testing libraries from the build configuration.
  * Cleaned up build metadata and test tooling references.
  * No changes to app functionality or user experience; users should see no behavioral differences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->