### PR TITLE
ci: run octocov on default branch too

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -107,7 +107,6 @@ jobs:
             ${{ runner.os }}-gradle-
       - run: devbox run ./gradlew detekt testDebugUnitTest koverXmlReportDebug
       - uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1.5.0
-        if: github.event_name == 'pull_request'
         with:
           config: octocov.yaml
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0


### PR DESCRIPTION
for pushing coverage report and compare them, we need to run it on default branch too.