### PR TITLE
ci: run once on pr

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -107,6 +107,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - run: devbox run ./gradlew detekt testDebugUnitTest koverXmlReportDebug
       - uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1.5.0
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
         with:
           config: octocov.yaml
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0


### PR DESCRIPTION
If you run it on the PR branch, it will be commented twice, so fix it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow to run code coverage checks more efficiently, now limited to pull requests and default branch pushes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->