### PR TITLE
refactor: use produceLibraries() for AboutLibraries v13.x compatibility

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/presentation/ui/LicenseScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/presentation/ui/LicenseScreen.kt
@@ -31,7 +31,7 @@ import io.github.omochice.pinosu.R
 fun LicenseScreen(onNavigateUp: () -> Unit) {
   val context = LocalContext.current
   val libraries by produceLibraries {
-    context.resources.openRawResource(R.raw.aboutlibraries).bufferedReader().readText()
+    context.resources.openRawResource(R.raw.aboutlibraries).bufferedReader().use { it.readText() }
   }
   Scaffold(
       topBar = {


### PR DESCRIPTION
When run `./gradlew assembleDebug`, we face:

```console
w: file:///Users/omochice/ghq/github.com/Omochice/Pinosu/app/src/main/java/io/github/omochice/pinosu/data/metadata/UrlMetadataFetcher.kt:55:26 Unnecessary safe call on a non-null receiver of type 'ResponseBody'.
w: file:///Users/omochice/ghq/github.com/Omochice/Pinosu/app/src/main/java/io/github/omochice/pinosu/presentation/ui/LicenseScreen.kt:41:9 'fun LibrariesContainer(modifier: Modifier = ..., libraryModifier: Modifier = ..., librariesBlock: (Context) -> Libs = ..., lazyListState: LazyListState = ..., contentPadding: PaddingValues = ..., showAuthor: Boolean = ..., showDescription: Boolean = ..., showVersion: Boolean = ..., showLicenseBadges: Boolean = ..., showFundingBadges: Boolean = ..., colors: LibraryColors = ..., padding: LibraryPadding = ..., dimensions: LibraryDimensions = ..., textStyles: LibraryTextStyles = ..., header: (LazyListScope.() -> Unit)? = ..., divider: ComposableFunction1<LazyItemScope, Unit>? = ..., footer: (LazyListScope.() -> Unit)? = ..., onLibraryClick: ((Library) -> Unit)? = ..., onFundingClick: ((Funding) -> Unit)? = ...): Unit' is deprecated. Use `LibrariesContainer` variant with `Libs` instead. Use `produceLibraries` to load the libraries.
```

So we fix them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * License screen now properly initializes and displays open-source license information.

* **Improvements**
  * More reliable loading and presentation of the libraries list to avoid blank or incomplete states when opening the license screen.
  * Improved responsiveness of the license view so entries appear consistently on first render.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->