### PR TITLE
ci: publish release draft on first

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "simple",
       "changelog-path": "CHANGELOG.md",
+      "draft": true,
       "include-component-in-tag": false,
       "extra-files": [
         {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,9 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write
-      - run: gh release upload "${TAG_NAME}" ./app/build/outputs/apk/release/app-release.apk
+      - run: |
+          gh release upload "${TAG_NAME}" ./app/build/outputs/apk/release/app-release.apk
+          gh release edit "${TAG_NAME}" --draft=false
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled draft releases by default in the release configuration.
  * Adjusted the release workflow to upload artifacts then mark releases as published.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->