### PR TITLE
refactor: remove unnecessary safe call on Nip55Error

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/data/repository/Nip55AuthRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/data/repository/Nip55AuthRepository.kt
@@ -91,8 +91,8 @@ constructor(
             is Nip55Error.NotInstalled -> LoginError.Nip55SignerNotInstalled
             is Nip55Error.UserRejected -> LoginError.UserRejected
             is Nip55Error.Timeout -> LoginError.Timeout
-            is Nip55Error.InvalidResponse,
-            is Nip55Error.IntentResolutionError -> LoginError.NetworkError(nip55Error.toString())
+            is Nip55Error.InvalidResponse -> LoginError.NetworkError(nip55Error.message)
+            is Nip55Error.IntentResolutionError -> LoginError.NetworkError(nip55Error.message)
             null -> LoginError.UnknownError(Exception("Unknown NIP-55 signer error"))
           }
       Result.failure(loginError)


### PR DESCRIPTION
This pull request makes a small improvement to error handling in the `Nip55AuthRepository` by ensuring that the error message for network errors always includes the string representation of the `nip55Error`, even when it is null.

* Improved error reporting for `Nip55Error.InvalidResponse` and `Nip55Error.IntentResolutionError` by always using `nip55Error.toString()` for the network error message, ensuring clearer error information.