### PR TITLE
chore: set `always-update` true

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -12,7 +12,8 @@
           "path": "version.json",
           "jsonpath": "$.versionName"
         }
-      ]
+      ],
+      "always-update": true
     }
   }
 }


### PR DESCRIPTION
when push `chore`, `refactor` commits, we block draft PR because it has not linear history.
it is not the behavior we with, so we change the option to rebase always.
