### PR TITLE
ci: use `claude_code_auth_token` instead

### DIFF
--- a/.github/workflows/auto-steering.yaml
+++ b/.github/workflows/auto-steering.yaml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
       - uses: anthropics/claude-code-action@70e16deb18402428bd09e08d1ec3662a872e3c72 # v1.0.41
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             /kiro:steering
       - uses: jetify-com/devbox-install-action@a0d2d53632934ae004f878c840055956d9f741b0 # v0.14.0


### PR DESCRIPTION
the value is set from `/install-github-app`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->