### PR TITLE
refactor: use @param instead of @property in KDoc for constructor args

### DIFF
--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -66,22 +66,6 @@
     <ID>NoWildcardImports:Nip55SignerClientTest.kt$import org.junit.Assert.*</ID>
     <ID>NoWildcardImports:PostBookmarkUseCaseTest.kt$import org.junit.Assert.*</ID>
     <ID>NoWildcardImports:PresentationDomainIntegrationTest.kt$import org.junit.Assert.*</ID>
-    <ID>OutdatedDocumentation:BookmarkFilterMode.kt$BookmarkFilterMode</ID>
-    <ID>OutdatedDocumentation:BookmarkScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun BookmarkScreen( uiState: BookmarkUiState, onRefresh: () -&gt; Unit, onLoad: () -&gt; Unit, onOpenDrawer: () -&gt; Unit = {}, onTabSelected: (BookmarkFilterMode) -&gt; Unit = {}, onAddBookmark: () -&gt; Unit = {}, onBookmarkDetailNavigate: (BookmarkItem) -&gt; Unit = {}, )</ID>
-    <ID>OutdatedDocumentation:BookmarkViewModel.kt$BookmarkViewModel : ViewModel</ID>
-    <ID>OutdatedDocumentation:FetchRelayListUseCase.kt$FetchRelayListUseCaseImpl : FetchRelayListUseCase</ID>
-    <ID>OutdatedDocumentation:GetBookmarkListUseCaseImpl.kt$GetBookmarkListUseCaseImpl : GetBookmarkListUseCase</ID>
-    <ID>OutdatedDocumentation:LoginViewModel.kt$LoginViewModel : ViewModel</ID>
-    <ID>OutdatedDocumentation:Nip55AuthRepository.kt$Nip55AuthRepository : AuthRepository</ID>
-    <ID>OutdatedDocumentation:Nip55GetLoginStateUseCase.kt$Nip55GetLoginStateUseCase : GetLoginStateUseCase</ID>
-    <ID>OutdatedDocumentation:Nip55LoginUseCase.kt$Nip55LoginUseCase : LoginUseCase</ID>
-    <ID>OutdatedDocumentation:Nip55LogoutUseCase.kt$Nip55LogoutUseCase : LogoutUseCase</ID>
-    <ID>OutdatedDocumentation:Nip65RelayListFetcher.kt$Nip65RelayListFetcherImpl : Nip65RelayListFetcher</ID>
-    <ID>OutdatedDocumentation:PostBookmarkUseCaseImpl.kt$PostBookmarkUseCaseImpl : PostBookmarkUseCase</ID>
-    <ID>OutdatedDocumentation:PostBookmarkViewModel.kt$PostBookmarkViewModel : ViewModel</ID>
-    <ID>OutdatedDocumentation:RelayBookmarkRepository.kt$RelayBookmarkRepository : BookmarkRepository</ID>
-    <ID>OutdatedDocumentation:RelayPool.kt$RelayPoolImpl : RelayPool</ID>
-    <ID>OutdatedDocumentation:UrlMetadataFetcher.kt$OkHttpUrlMetadataFetcher : UrlMetadataFetcher</ID>
     <ID>ReturnCount:LocalAuthDataSource.kt$LocalAuthDataSource$suspend fun getUser(): User?</ID>
     <ID>ReturnCount:Nip55SignerClient.kt$Nip55SignerClient$fun handleNip55Response(resultCode: Int, data: Intent?): Result&lt;Nip55Response&gt;</ID>
     <ID>ReturnCount:Nip55SignerClient.kt$Nip55SignerClient$fun handleSignEventResponse(resultCode: Int, data: Intent?): Result&lt;SignedEventResponse&gt;</ID>

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip65/Nip65RelayListFetcher.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip65/Nip65RelayListFetcher.kt
@@ -23,10 +23,10 @@ interface Nip65RelayListFetcher {
 }
 
 /**
- * Implementation of Nip65RelayListFetcher
+ * Implementation of [Nip65RelayListFetcher]
  *
- * @property relayPool Pool for querying Nostr relays
- * @property parser Parser for NIP-65 events
+ * @param relayPool Pool for querying Nostr relays
+ * @param parser Parser for NIP-65 events
  */
 @Singleton
 class Nip65RelayListFetcherImpl

--- a/app/src/main/java/io/github/omochice/pinosu/core/relay/RelayPool.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/relay/RelayPool.kt
@@ -66,9 +66,9 @@ interface RelayPool {
 }
 
 /**
- * Implementation of RelayPool that manages parallel connections to multiple Nostr relays
+ * Implementation of [RelayPool] that manages parallel connections to multiple Nostr relays
  *
- * @property okHttpClient OkHttpClient for WebSocket connections
+ * @param okHttpClient HTTP client for WebSocket connections
  */
 @Singleton
 class RelayPoolImpl @Inject constructor(private val okHttpClient: OkHttpClient) : RelayPool {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/data/repository/Nip55AuthRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/data/repository/Nip55AuthRepository.kt
@@ -12,13 +12,13 @@ import io.github.omochice.pinosu.feature.auth.domain.model.error.StorageError
 import javax.inject.Inject
 
 /**
- * NIP-55 based AuthRepository implementation
+ * NIP-55 based [AuthRepository] implementation
  *
- * Integrates Nip55SignerClient and LocalAuthDataSource to provide authentication flow and local
+ * Integrates [Nip55SignerClient] and [LocalAuthDataSource] to provide authentication flow and local
  * state management.
  *
- * @property nip55SignerClient NIP-55 signer communication client
- * @property localAuthDataSource Local storage data source
+ * @param nip55SignerClient Client for NIP-55 signer interaction
+ * @param localAuthDataSource Local data source for user authentication state
  */
 class Nip55AuthRepository
 @Inject

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/usecase/FetchRelayListUseCase.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/usecase/FetchRelayListUseCase.kt
@@ -25,10 +25,10 @@ interface FetchRelayListUseCase {
 }
 
 /**
- * Implementation of FetchRelayListUseCase
+ * Implementation of [FetchRelayListUseCase]
  *
- * @property fetcher NIP-65 relay list fetcher
- * @property localAuthDataSource Local data source for caching relay list
+ * @param fetcher Fetcher for NIP-65 relay list metadata
+ * @param localAuthDataSource Local data source for caching relay list
  */
 class FetchRelayListUseCaseImpl
 @Inject

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/usecase/Nip55GetLoginStateUseCase.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/usecase/Nip55GetLoginStateUseCase.kt
@@ -5,9 +5,9 @@ import io.github.omochice.pinosu.feature.auth.domain.model.User
 import javax.inject.Inject
 
 /**
- * NIP-55 based GetLoginStateUseCase implementation class
+ * NIP-55 based [GetLoginStateUseCase] implementation
  *
- * @property authRepository Authentication repository
+ * @param authRepository Repository for authentication operations
  */
 class Nip55GetLoginStateUseCase @Inject constructor(private val authRepository: AuthRepository) :
     GetLoginStateUseCase {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/usecase/Nip55LoginUseCase.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/usecase/Nip55LoginUseCase.kt
@@ -4,9 +4,9 @@ import io.github.omochice.pinosu.feature.auth.data.repository.AuthRepository
 import javax.inject.Inject
 
 /**
- * NIP-55 based LoginUseCase implementation
+ * NIP-55 based [LoginUseCase] implementation
  *
- * @property authRepository Authentication repository
+ * @param authRepository Repository for authentication operations
  */
 class Nip55LoginUseCase @Inject constructor(private val authRepository: AuthRepository) :
     LoginUseCase {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/usecase/Nip55LogoutUseCase.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/usecase/Nip55LogoutUseCase.kt
@@ -4,9 +4,9 @@ import io.github.omochice.pinosu.feature.auth.data.repository.AuthRepository
 import javax.inject.Inject
 
 /**
- * NIP-55 based LogoutUseCase implementation
+ * NIP-55 based [LogoutUseCase] implementation
  *
- * @property authRepository Authentication repository
+ * @param authRepository Repository for authentication operations
  */
 class Nip55LogoutUseCase @Inject constructor(private val authRepository: AuthRepository) :
     LogoutUseCase {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/presentation/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/presentation/viewmodel/LoginViewModel.kt
@@ -20,11 +20,11 @@ import kotlinx.coroutines.launch
 /**
  * ViewModel for login/logout screen
  *
- * @property loginUseCase UseCase for login processing
- * @property logoutUseCase UseCase for logout processing
- * @property getLoginStateUseCase UseCase for retrieving login state
- * @property authRepository Authentication repository (for NIP-55 signer response processing)
- * @property fetchRelayListUseCase UseCase for fetching NIP-65 relay list
+ * @param loginUseCase UseCase for login operations
+ * @param logoutUseCase UseCase for logout operations
+ * @param getLoginStateUseCase UseCase for retrieving current login state
+ * @param authRepository Repository for processing NIP-55 signer responses
+ * @param fetchRelayListUseCase UseCase for fetching NIP-65 relay list after login
  */
 @HiltViewModel
 class LoginViewModel

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/metadata/UrlMetadataFetcher.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/metadata/UrlMetadataFetcher.kt
@@ -16,9 +16,9 @@ interface UrlMetadataFetcher {
 }
 
 /**
- * Implementation of UrlMetadataFetcher using OkHttp and Jsoup
+ * Implementation of [UrlMetadataFetcher] using OkHttp and Jsoup
  *
- * @property okHttpClient OkHttp client for HTTP requests
+ * @param okHttpClient HTTP client for fetching URL content
  */
 @Singleton
 class OkHttpUrlMetadataFetcher @Inject constructor(private val okHttpClient: OkHttpClient) :

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
@@ -16,14 +16,14 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Relay-based implementation of BookmarkRepository
+ * Relay-based implementation of [BookmarkRepository]
  *
  * Fetches kind:39701 bookmark events from multiple Nostr relays in parallel, deduplicates results,
  * and enriches them with URL metadata (og:title) when title tags are not present.
  *
- * @property relayPool Pool for parallel relay queries
- * @property localAuthDataSource Local data source for cached relay list
- * @property urlMetadataFetcher Fetcher for URL Open Graph metadata
+ * @param relayPool Pool for querying Nostr relays
+ * @param localAuthDataSource Local data source for cached authentication and relay data
+ * @param urlMetadataFetcher Fetcher for URL metadata (og:title)
  */
 @Singleton
 class RelayBookmarkRepository

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/usecase/GetBookmarkListUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/usecase/GetBookmarkListUseCaseImpl.kt
@@ -5,11 +5,11 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkList
 import javax.inject.Inject
 
 /**
- * Implementation of GetBookmarkListUseCase
+ * Implementation of [GetBookmarkListUseCase]
  *
- * Delegates to BookmarkRepository to fetch bookmark events from relays.
+ * Delegates to [BookmarkRepository] to fetch bookmark events from relays.
  *
- * @property bookmarkRepository Repository for bookmark data access
+ * @param bookmarkRepository Repository for bookmark operations
  */
 class GetBookmarkListUseCaseImpl
 @Inject

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkFilterMode.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkFilterMode.kt
@@ -1,12 +1,10 @@
 package io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel
 
-/**
- * Filter mode for bookmark list display
- *
- * @property Local Shows only the logged-in user's own bookmarks
- * @property Global Shows all bookmarks from the relay
- */
+/** Filter mode for bookmark list display */
 enum class BookmarkFilterMode {
+  /** Shows only the logged-in user's own bookmarks */
   Local,
+
+  /** Shows all bookmarks from the relay */
   Global
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
@@ -22,9 +22,9 @@ import kotlinx.coroutines.launch
  * Manages bookmark data loading and UI state for the bookmark list display. Observes display mode
  * changes for immediate UI updates.
  *
- * @property getBookmarkListUseCase UseCase for fetching bookmark list
- * @property getLoginStateUseCase UseCase for retrieving current login state
- * @property observeDisplayModeUseCase UseCase for observing display mode preference changes
+ * @param getBookmarkListUseCase UseCase for fetching bookmark list from relays
+ * @param getLoginStateUseCase UseCase for retrieving current login state
+ * @param observeDisplayModeUseCase UseCase for observing display mode preference changes
  */
 @HiltViewModel
 class BookmarkViewModel

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/domain/usecase/PostBookmarkUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/domain/usecase/PostBookmarkUseCaseImpl.kt
@@ -8,10 +8,10 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Implementation of PostBookmarkUseCase
+ * Implementation of [PostBookmarkUseCase]
  *
- * @property bookmarkRepository Repository for bookmark operations
- * @property getLoginStateUseCase Use case for getting current user
+ * @param bookmarkRepository Repository for bookmark operations
+ * @param getLoginStateUseCase UseCase for retrieving current login state
  */
 @Singleton
 class PostBookmarkUseCaseImpl

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
@@ -19,8 +19,8 @@ import kotlinx.coroutines.launch
  *
  * Manages form state and handles bookmark posting flow including NIP-55 signing.
  *
- * @property postBookmarkUseCase Use case for creating and publishing bookmarks
- * @property nip55SignerClient Client for NIP-55 signing operations
+ * @param postBookmarkUseCase UseCase for creating and publishing bookmark events
+ * @param nip55SignerClient Client for NIP-55 signer interaction
  */
 @HiltViewModel
 class PostBookmarkViewModel


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved and standardized documentation formatting across authentication and bookmark management features.
  * Enhanced parameter documentation with clearer descriptions and better cross-references throughout relevant components.

* **Chores**
  * Cleaned up obsolete baseline documentation entries to maintain current and accurate codebase references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->