### PR TITLE
refactor: merge values-v23 theme into values since minSdk is 30

### DIFF
--- a/app/src/main/res/values-v23/themes.xml
+++ b/app/src/main/res/values-v23/themes.xml
@@ -1,4 +1,0 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-
-    <style name="Theme.Pinosu" parent="Base.Theme.Pinosu" />
-</resources>


### PR DESCRIPTION
## Summary
- Merge transparent system bar settings from `values-v23/themes.xml` into `values/themes.xml`
- Delete the `values-v23/` directory since `minSdk=30` makes the API 23 qualifier unnecessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed unused Android theme resources to streamline the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->