### PR TITLE
ci: enable KVM for Android emulator in CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -170,6 +170,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Run instrumented tests with coverage
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:


### PR DESCRIPTION
## Summary

Enable KVM hardware acceleration for the Android emulator on GitHub Actions ubuntu runners.

## Details

The `instrumentation-test` job was failing because `ubuntu-latest` runners lack KVM by default, causing the x86_64 emulator to run without hardware acceleration. This follows the setup recommended by `reactivecircus/android-emulator-runner`.

## Confirmation

- Verify the `instrumentation-test` job passes on the PR's CI run

## Limitation

No known limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced instrumented test environment configuration for improved test execution and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->