### PR TITLE
ci: add actions-timeline to check workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -342,8 +342,10 @@ jobs:
       - instrumentation-test
       - test-android
       # keep-sorted end
-    permissions: {}
+    permissions:
+      actions: read
     if: always()
     steps:
+      - uses: Kesin11/actions-timeline@44c9c178ffb2fb1d9859614a3ffa79ccfb77565e # v3.1.0
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1


### PR DESCRIPTION
## Summary

Add actions-timeline to the check workflow to visualize CI execution as a Gantt chart on the Actions summary page.

## Details

The check workflow has many parallel and sequential jobs, but there was no easy way to see their timing relationships at a glance. actions-timeline (Kesin11/actions-timeline v3.1.0) renders a Gantt chart in the workflow run summary, making it straightforward to identify bottlenecks.

The action is placed in the `status-check` job because it depends on all other jobs via `needs` and runs unconditionally with `if: always()`, ensuring the timeline captures the full workflow. The `actions: read` permission is added to allow the action to query the GitHub API for job timing data.

## Confirmation

- Verify the check workflow completes successfully
- Open the Actions summary page for a workflow run and confirm the Gantt chart is rendered

## Limitation

No known limitations.