### PR TITLE
feat: edit own kind 39701 bookmark events

### DIFF
--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreenTest.kt
@@ -114,6 +114,51 @@ class BookmarkDetailScreenTest {
   }
 
   @Test
+  fun editButtonShouldBeVisibleWhenOnEditBookmarkIsProvided() {
+    composeTestRule.setContent {
+      BookmarkDetailScreen(
+          uiState = BookmarkDetailUiState(),
+          bookmarkInfo =
+              BookmarkInfo(
+                  title = "Test",
+                  urls = listOf("https://example.com"),
+                  createdAt = 1_700_000_000L,
+                  authorPubkey = "pk_author"),
+          onCommentInputChange = {},
+          onPostComment = {},
+          onNavigateBack = {},
+          onDismissError = {},
+          onEditBookmark = {})
+    }
+
+    composeTestRule
+        .onNodeWithContentDescription(getTestString(R.string.cd_edit_bookmark))
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun editButtonShouldBeHiddenWhenOnEditBookmarkIsNull() {
+    composeTestRule.setContent {
+      BookmarkDetailScreen(
+          uiState = BookmarkDetailUiState(),
+          bookmarkInfo =
+              BookmarkInfo(
+                  title = "Test",
+                  urls = listOf("https://example.com"),
+                  createdAt = 1_700_000_000L,
+                  authorPubkey = "pk_author"),
+          onCommentInputChange = {},
+          onPostComment = {},
+          onNavigateBack = {},
+          onDismissError = {})
+    }
+
+    composeTestRule
+        .onNodeWithContentDescription(getTestString(R.string.cd_edit_bookmark))
+        .assertDoesNotExist()
+  }
+
+  @Test
   fun commentInputBarShouldBeHiddenWhenReadOnly() {
     composeTestRule.setContent {
       BookmarkDetailScreen(

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreenTest.kt
@@ -2,6 +2,7 @@ package io.github.omochice.pinosu.feature.postbookmark.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.feature.postbookmark.presentation.viewmodel.PostBookmarkUiState
@@ -36,7 +37,7 @@ class PostBookmarkScreenTest {
           onDismissError = {})
     }
 
-    composeTestRule.onNodeWithText("example.com/article").assertIsDisplayed()
+    composeTestRule.onNodeWithTag(URL_FIELD_TEST_TAG).assertIsDisplayed()
     assertFalse("onUrlChange should not be called in read-only mode", urlChanged)
   }
 

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreenTest.kt
@@ -1,0 +1,73 @@
+package io.github.omochice.pinosu.feature.postbookmark.presentation.ui
+
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import io.github.omochice.pinosu.R
+import io.github.omochice.pinosu.feature.postbookmark.presentation.viewmodel.PostBookmarkUiState
+import io.github.omochice.pinosu.getTestString
+import org.junit.Rule
+import org.junit.Test
+
+/** Compose UI tests for [PostBookmarkScreen] */
+class PostBookmarkScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun urlFieldShouldBeDisabledInEditMode() {
+    composeTestRule.setContent {
+      PostBookmarkScreen(
+          uiState =
+              PostBookmarkUiState(
+                  url = "example.com/article",
+                  title = "Title",
+                  categories = "tech",
+                  comment = "Comment",
+                  isEditMode = true),
+          onUrlChange = {},
+          onTitleChange = {},
+          onCategoriesChange = {},
+          onCommentChange = {},
+          onPostClick = {},
+          onNavigateBack = {},
+          onDismissError = {})
+    }
+
+    composeTestRule.onNodeWithText("example.com/article").assertIsNotEnabled()
+  }
+
+  @Test
+  fun titleShouldShowEditBookmarkInEditMode() {
+    composeTestRule.setContent {
+      PostBookmarkScreen(
+          uiState = PostBookmarkUiState(url = "example.com/article", isEditMode = true),
+          onUrlChange = {},
+          onTitleChange = {},
+          onCategoriesChange = {},
+          onCommentChange = {},
+          onPostClick = {},
+          onNavigateBack = {},
+          onDismissError = {})
+    }
+
+    composeTestRule.onNodeWithText(getTestString(R.string.title_edit_bookmark)).assertExists()
+  }
+
+  @Test
+  fun titleShouldShowAddBookmarkInCreateMode() {
+    composeTestRule.setContent {
+      PostBookmarkScreen(
+          uiState = PostBookmarkUiState(),
+          onUrlChange = {},
+          onTitleChange = {},
+          onCategoriesChange = {},
+          onCommentChange = {},
+          onPostClick = {},
+          onNavigateBack = {},
+          onDismissError = {})
+    }
+
+    composeTestRule.onNodeWithText(getTestString(R.string.title_post_bookmark)).assertExists()
+  }
+}

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreenTest.kt
@@ -1,11 +1,12 @@
 package io.github.omochice.pinosu.feature.postbookmark.presentation.ui
 
-import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.feature.postbookmark.presentation.viewmodel.PostBookmarkUiState
 import io.github.omochice.pinosu.getTestString
+import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
 
@@ -15,7 +16,8 @@ class PostBookmarkScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test
-  fun urlFieldShouldBeDisabledInEditMode() {
+  fun urlFieldShouldBeReadOnlyInEditMode() {
+    var urlChanged = false
     composeTestRule.setContent {
       PostBookmarkScreen(
           uiState =
@@ -25,7 +27,7 @@ class PostBookmarkScreenTest {
                   categories = "tech",
                   comment = "Comment",
                   isEditMode = true),
-          onUrlChange = {},
+          onUrlChange = { urlChanged = true },
           onTitleChange = {},
           onCategoriesChange = {},
           onCommentChange = {},
@@ -34,7 +36,8 @@ class PostBookmarkScreenTest {
           onDismissError = {})
     }
 
-    composeTestRule.onNodeWithText("example.com/article").assertIsNotEnabled()
+    composeTestRule.onNodeWithText("example.com/article").assertIsDisplayed()
+    assertFalse("onUrlChange should not be called in read-only mode", urlChanged)
   }
 
   @Test

--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -384,7 +384,7 @@ fun PinosuApp(
 
                 LaunchedEffect(postBookmarkUiState.postSuccess) {
                   if (postBookmarkUiState.postSuccess) {
-                    postBookmarkViewModel.resetPostSuccess()
+                    postBookmarkViewModel.resetForm()
                     navController.navigateUp()
                   }
                 }
@@ -397,6 +397,7 @@ fun PinosuApp(
                         categories = postBookmarkRoute.editCategories.orEmpty(),
                         comment = postBookmarkRoute.editComment.orEmpty())
                   } else {
+                    postBookmarkViewModel.resetForm()
                     postBookmarkRoute.sharedUrl?.let { postBookmarkViewModel.updateUrl(it) }
                     postBookmarkRoute.sharedComment?.let { postBookmarkViewModel.updateComment(it) }
                   }

--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -561,7 +561,7 @@ private fun navigateToBookmarkDetail(
   val event = bookmark.event ?: return
   val dTag = event.tags.firstOrNull { it.isNotEmpty() && it[0] == "d" }?.getOrNull(1) ?: return
   val eventId = bookmark.eventId ?: return
-  val categories = event.tags.filter { it.size >= 2 && it[0] == "t" }.joinToString(", ") { it[1] }
+  val categories = event.tags.filter { it.size >= 2 && it[0] == "t" }.map { it[1] }
   navController.navigate(
       BookmarkDetail(
           eventId = eventId,

--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import dagger.hilt.android.AndroidEntryPoint
+import io.github.omochice.pinosu.core.model.Pubkey
 import io.github.omochice.pinosu.core.navigation.AppInfo
 import io.github.omochice.pinosu.core.navigation.Bookmark
 import io.github.omochice.pinosu.core.navigation.BookmarkDetail
@@ -480,7 +481,8 @@ fun PinosuApp(
                     isReadOnly = mainUiState.isReadOnly,
                     onEditBookmark =
                         if (!mainUiState.isReadOnly &&
-                            route.authorPubkey == mainUiState.userPubkey) {
+                            route.authorPubkey ==
+                                mainUiState.userPubkey?.let { Pubkey.parse(it)?.hex }) {
                           {
                             navController.navigate(
                                 PostBookmark(

--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -533,6 +533,7 @@ private fun navigateToBookmarkDetail(
   val event = bookmark.event ?: return
   val dTag = event.tags.firstOrNull { it.isNotEmpty() && it[0] == "d" }?.getOrNull(1) ?: return
   val eventId = bookmark.eventId ?: return
+  val categories = event.tags.filter { it.size >= 2 && it[0] == "t" }.joinToString(", ") { it[1] }
   navController.navigate(
       BookmarkDetail(
           eventId = eventId,
@@ -543,5 +544,6 @@ private fun navigateToBookmarkDetail(
           createdAt = event.createdAt,
           urls = bookmark.urls,
           imageUrl = bookmark.imageUrl,
+          categories = categories,
       ))
 }

--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -389,8 +389,16 @@ fun PinosuApp(
                 }
 
                 LaunchedEffect(postBookmarkRoute) {
-                  postBookmarkRoute.sharedUrl?.let { postBookmarkViewModel.updateUrl(it) }
-                  postBookmarkRoute.sharedComment?.let { postBookmarkViewModel.updateComment(it) }
+                  if (postBookmarkRoute.editUrl != null) {
+                    postBookmarkViewModel.initializeForEdit(
+                        url = postBookmarkRoute.editUrl,
+                        title = postBookmarkRoute.editTitle.orEmpty(),
+                        categories = postBookmarkRoute.editCategories.orEmpty(),
+                        comment = postBookmarkRoute.editComment.orEmpty())
+                  } else {
+                    postBookmarkRoute.sharedUrl?.let { postBookmarkViewModel.updateUrl(it) }
+                    postBookmarkRoute.sharedComment?.let { postBookmarkViewModel.updateComment(it) }
+                  }
                 }
 
                 PostBookmarkScreen(
@@ -469,7 +477,22 @@ fun PinosuApp(
                     onNavigateBack = { navController.navigateUp() },
                     onDismissError = { detailViewModel.dismissError() },
                     onOpenUrlFailed = { detailViewModel.onOpenUrlFailed() },
-                    isReadOnly = mainUiState.isReadOnly)
+                    isReadOnly = mainUiState.isReadOnly,
+                    onEditBookmark =
+                        if (!mainUiState.isReadOnly &&
+                            route.authorPubkey == mainUiState.userPubkey) {
+                          {
+                            navController.navigate(
+                                PostBookmark(
+                                    editUrl = route.dTag,
+                                    editTitle = route.title,
+                                    editCategories = route.categories,
+                                    editComment = route.content,
+                                ))
+                          }
+                        } else {
+                          null
+                        })
               }
 
           composable<License>(

--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -481,20 +481,22 @@ fun PinosuApp(
                     onOpenUrlFailed = { detailViewModel.onOpenUrlFailed() },
                     isReadOnly = mainUiState.isReadOnly,
                     onEditBookmark =
-                        if (!mainUiState.isReadOnly &&
-                            route.authorPubkey ==
-                                mainUiState.userPubkey?.let { Pubkey.parse(it)?.hex }) {
-                          {
-                            navController.navigate(
-                                PostBookmark(
-                                    editUrl = route.dTag,
-                                    editTitle = route.title,
-                                    editCategories = route.categories,
-                                    editComment = route.content,
-                                ))
+                        remember(mainUiState.isReadOnly, mainUiState.userPubkey, route) {
+                          if (!mainUiState.isReadOnly &&
+                              route.authorPubkey ==
+                                  mainUiState.userPubkey?.let { Pubkey.parse(it)?.hex }) {
+                            {
+                              navController.navigate(
+                                  PostBookmark(
+                                      editUrl = route.dTag,
+                                      editTitle = route.title,
+                                      editCategories = route.categories,
+                                      editComment = route.content,
+                                  ))
+                            }
+                          } else {
+                            null
                           }
-                        } else {
-                          null
                         })
               }
 

--- a/app/src/main/java/io/github/omochice/pinosu/core/navigation/Navigation.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/navigation/Navigation.kt
@@ -24,9 +24,20 @@ sealed interface Route
  *
  * @property sharedUrl Pre-filled URL from share intent, or null
  * @property sharedComment Pre-filled comment from share intent, or null
+ * @property editUrl URL of the bookmark being edited (without scheme), or null for new bookmark
+ * @property editTitle Title of the bookmark being edited, or null for new bookmark
+ * @property editCategories Comma-separated categories of the bookmark being edited, or null
+ * @property editComment Comment of the bookmark being edited, or null
  */
 @Serializable
-data class PostBookmark(val sharedUrl: String? = null, val sharedComment: String? = null) : Route
+data class PostBookmark(
+    val sharedUrl: String? = null,
+    val sharedComment: String? = null,
+    val editUrl: String? = null,
+    val editTitle: String? = null,
+    val editCategories: String? = null,
+    val editComment: String? = null,
+) : Route
 
 /**
  * Bookmark detail screen route
@@ -39,6 +50,7 @@ data class PostBookmark(val sharedUrl: String? = null, val sharedComment: String
  * @property createdAt Unix timestamp of the bookmark event
  * @property urls List of bookmark URLs
  * @property imageUrl OGP image URL, or null if not available
+ * @property categories Comma-separated category string from t-tags
  */
 @Serializable
 data class BookmarkDetail(
@@ -50,6 +62,7 @@ data class BookmarkDetail(
     val createdAt: Long = 0L,
     val urls: List<String> = emptyList(),
     val imageUrl: String? = null,
+    val categories: String = "",
 ) : Route
 
 /** Settings screen route */

--- a/app/src/main/java/io/github/omochice/pinosu/core/navigation/Navigation.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/navigation/Navigation.kt
@@ -26,7 +26,7 @@ sealed interface Route
  * @property sharedComment Pre-filled comment from share intent, or null
  * @property editUrl URL of the bookmark being edited (without scheme), or null for new bookmark
  * @property editTitle Title of the bookmark being edited, or null for new bookmark
- * @property editCategories Comma-separated categories of the bookmark being edited, or null
+ * @property editCategories Categories of the bookmark being edited, or null
  * @property editComment Comment of the bookmark being edited, or null
  */
 @Serializable
@@ -35,7 +35,7 @@ data class PostBookmark(
     val sharedComment: String? = null,
     val editUrl: String? = null,
     val editTitle: String? = null,
-    val editCategories: String? = null,
+    val editCategories: List<String>? = null,
     val editComment: String? = null,
 ) : Route
 
@@ -50,7 +50,7 @@ data class PostBookmark(
  * @property createdAt Unix timestamp of the bookmark event
  * @property urls List of bookmark URLs
  * @property imageUrl OGP image URL, or null if not available
- * @property categories Comma-separated category string from t-tags
+ * @property categories List of category strings from t-tags
  */
 @Serializable
 data class BookmarkDetail(
@@ -62,7 +62,7 @@ data class BookmarkDetail(
     val createdAt: Long = 0L,
     val urls: List<String> = emptyList(),
     val imageUrl: String? = null,
-    val categories: String = "",
+    val categories: List<String> = emptyList(),
 ) : Route
 
 /** Settings screen route */

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -59,6 +60,7 @@ import io.github.omochice.pinosu.ui.component.ErrorDialog
  * @param onDismissError Callback to dismiss error dialog
  * @param onOpenUrlFailed Callback when opening a URL fails
  * @param isReadOnly Whether to hide comment input for read-only login
+ * @param onEditBookmark Callback when edit button is clicked, or null to hide the button
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -71,6 +73,7 @@ fun BookmarkDetailScreen(
     onDismissError: () -> Unit = {},
     onOpenUrlFailed: () -> Unit = {},
     isReadOnly: Boolean = false,
+    onEditBookmark: (() -> Unit)? = null,
 ) {
   Scaffold(
       topBar = {
@@ -86,6 +89,15 @@ fun BookmarkDetailScreen(
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = stringResource(R.string.cd_navigate_up))
+              }
+            },
+            actions = {
+              onEditBookmark?.let { onEdit ->
+                IconButton(onClick = onEdit) {
+                  Icon(
+                      imageVector = Icons.Filled.Edit,
+                      contentDescription = stringResource(R.string.cd_edit_bookmark))
+                }
               }
             })
       },

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreen.kt
@@ -115,7 +115,7 @@ fun PostBookmarkScreen(
                           onValueChange = onUrlChange,
                           modifier = Modifier.weight(1f),
                           singleLine = true,
-                          enabled = !uiState.isEditMode,
+                          readOnly = uiState.isEditMode,
                           placeholder = { Text("example.com/path") })
                     }
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreen.kt
@@ -62,7 +62,12 @@ fun PostBookmarkScreen(
   Scaffold(
       topBar = {
         TopAppBar(
-            title = { Text(stringResource(R.string.title_post_bookmark)) },
+            title = {
+              Text(
+                  stringResource(
+                      if (uiState.isEditMode) R.string.title_edit_bookmark
+                      else R.string.title_post_bookmark))
+            },
             navigationIcon = {
               IconButton(onClick = onNavigateBack) {
                 Icon(
@@ -107,6 +112,7 @@ fun PostBookmarkScreen(
                           onValueChange = onUrlChange,
                           modifier = Modifier.weight(1f),
                           singleLine = true,
+                          enabled = !uiState.isEditMode,
                           placeholder = { Text("example.com/path") })
                     }
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreen.kt
@@ -63,10 +63,13 @@ fun PostBookmarkScreen(
       topBar = {
         TopAppBar(
             title = {
-              Text(
-                  stringResource(
-                      if (uiState.isEditMode) R.string.title_edit_bookmark
-                      else R.string.title_post_bookmark))
+              val titleRes =
+                  if (uiState.isEditMode) {
+                    R.string.title_edit_bookmark
+                  } else {
+                    R.string.title_post_bookmark
+                  }
+              Text(stringResource(titleRes))
             },
             navigationIcon = {
               IconButton(onClick = onNavigateBack) {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -113,7 +114,7 @@ fun PostBookmarkScreen(
                       OutlinedTextField(
                           value = uiState.url,
                           onValueChange = onUrlChange,
-                          modifier = Modifier.weight(1f),
+                          modifier = Modifier.weight(1f).testTag(URL_FIELD_TEST_TAG),
                           singleLine = true,
                           readOnly = uiState.isEditMode,
                           placeholder = { Text("example.com/path") })
@@ -215,3 +216,6 @@ private fun PostBookmarkScreenLoadingPreview() {
       onNavigateBack = {},
       onDismissError = {})
 }
+
+/** Test tag for the URL input field */
+const val URL_FIELD_TEST_TAG = "url_field"

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkUiState.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkUiState.kt
@@ -10,6 +10,7 @@ package io.github.omochice.pinosu.feature.postbookmark.presentation.viewmodel
  * @property isSubmitting Whether the form is being submitted
  * @property errorMessage Error message to display
  * @property postSuccess Whether the post was successful
+ * @property isEditMode Whether the form is in edit mode (editing an existing bookmark)
  */
 data class PostBookmarkUiState(
     val url: String = "",
@@ -19,4 +20,5 @@ data class PostBookmarkUiState(
     val isSubmitting: Boolean = false,
     val errorMessage: String? = null,
     val postSuccess: Boolean = false,
+    val isEditMode: Boolean = false,
 )

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
@@ -80,13 +80,17 @@ constructor(
    *
    * @param url URL without scheme (read-only in edit mode)
    * @param title Existing bookmark title
-   * @param categories Existing comma-separated categories
+   * @param categories Existing categories list
    * @param comment Existing bookmark comment
    */
-  fun initializeForEdit(url: String, title: String, categories: String, comment: String) {
+  fun initializeForEdit(url: String, title: String, categories: List<String>, comment: String) {
     _uiState.update {
       it.copy(
-          url = url, title = title, categories = categories, comment = comment, isEditMode = true)
+          url = url,
+          title = title,
+          categories = categories.joinToString(", "),
+          comment = comment,
+          isEditMode = true)
     }
   }
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
@@ -44,7 +44,6 @@ constructor(
    * @param input Raw URL input from user
    */
   fun updateUrl(input: String) {
-    if (_uiState.value.isEditMode) return
     val strippedUrl = stripUrlScheme(input)
     _uiState.update { it.copy(url = strippedUrl) }
   }
@@ -91,14 +90,14 @@ constructor(
     }
   }
 
+  /** Reset form to initial state for new bookmark creation */
+  fun resetForm() {
+    _uiState.value = PostBookmarkUiState()
+  }
+
   /** Dismiss error message */
   fun dismissError() {
     _uiState.update { it.copy(errorMessage = null) }
-  }
-
-  /** Reset post success state */
-  fun resetPostSuccess() {
-    _uiState.update { it.copy(postSuccess = false) }
   }
 
   /**

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
@@ -75,6 +75,21 @@ constructor(
     _uiState.update { it.copy(comment = comment) }
   }
 
+  /**
+   * Initialize the form for editing an existing bookmark
+   *
+   * @param url URL without scheme (read-only in edit mode)
+   * @param title Existing bookmark title
+   * @param categories Existing comma-separated categories
+   * @param comment Existing bookmark comment
+   */
+  fun initializeForEdit(url: String, title: String, categories: String, comment: String) {
+    _uiState.update {
+      it.copy(
+          url = url, title = title, categories = categories, comment = comment, isEditMode = true)
+    }
+  }
+
   /** Dismiss error message */
   fun dismissError() {
     _uiState.update { it.copy(errorMessage = null) }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
@@ -181,18 +181,12 @@ constructor(
           }
         }
   }
+}
 
-  /**
-   * Strip http:// or https:// scheme from URL
-   *
-   * @param url URL that may contain scheme
-   * @return URL without scheme
-   */
-  private fun stripUrlScheme(url: String): String {
-    return when {
-      url.startsWith("https://", ignoreCase = true) -> url.substring("https://".length)
-      url.startsWith("http://", ignoreCase = true) -> url.substring("http://".length)
-      else -> url
-    }
+private fun stripUrlScheme(url: String): String {
+  return when {
+    url.startsWith("https://", ignoreCase = true) -> url.substring("https://".length)
+    url.startsWith("http://", ignoreCase = true) -> url.substring("http://".length)
+    else -> url
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
@@ -44,6 +44,7 @@ constructor(
    * @param input Raw URL input from user
    */
   fun updateUrl(input: String) {
+    if (_uiState.value.isEditMode) return
     val strippedUrl = stripUrlScheme(input)
     _uiState.update { it.copy(url = strippedUrl) }
   }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -59,6 +59,7 @@
     <string name="language_mode_japanese">日本語</string>
 
     <string name="title_post_bookmark">ブックマークを追加</string>
+    <string name="title_edit_bookmark">ブックマークを編集</string>
     <string name="label_title">タイトル</string>
     <string name="hint_bookmark_title">ブックマークのタイトル</string>
     <string name="label_categories">カテゴリ</string>
@@ -86,6 +87,7 @@
     <string name="cd_author_avatar">投稿者のプロフィール画像</string>
     <string name="cd_commenter_avatar">コメント投稿者のプロフィール画像</string>
     <string name="cd_remove_relay">リレーを削除</string>
+    <string name="cd_edit_bookmark">ブックマークを編集</string>
 
     <string name="settings_bootstrap_relays">ブートストラップリレー</string>
     <string name="settings_bootstrap_relays_description">リレーリストメタデータ（kind 10002）の取得に使用するリレー</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="cd_author_avatar">Author profile image</string>
     <string name="cd_commenter_avatar">Commenter profile image</string>
     <string name="cd_remove_relay">Remove relay</string>
+    <string name="cd_edit_bookmark">Edit bookmark</string>
 
     <string name="settings_bootstrap_relays">Bootstrap Relays</string>
     <string name="settings_bootstrap_relays_description">Relays used to fetch relay list metadata (kind 10002)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="language_mode_japanese">Japanese</string>
 
     <string name="title_post_bookmark">Add Bookmark</string>
+    <string name="title_edit_bookmark">Edit Bookmark</string>
     <string name="label_title">Title</string>
     <string name="hint_bookmark_title">Bookmark title</string>
     <string name="label_categories">Categories</string>

--- a/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
@@ -153,15 +153,6 @@ class PostBookmarkViewModelTest {
   }
 
   @Test
-  fun `resetPostSuccess should set postSuccess to false`() = runTest {
-    viewModel.resetPostSuccess()
-    advanceUntilIdle()
-
-    val state = viewModel.uiState.first()
-    assertFalse("postSuccess should be false", state.postSuccess)
-  }
-
-  @Test
   fun `prepareSignEventIntent should set error when URL is blank`() = runTest {
     viewModel.updateUrl("")
     advanceUntilIdle()
@@ -328,16 +319,20 @@ class PostBookmarkViewModelTest {
   }
 
   @Test
-  fun `updateUrl should be ignored in edit mode`() = runTest {
+  fun `resetForm should clear edit mode and all fields`() = runTest {
     viewModel.initializeForEdit(
         url = "example.com/article", title = "Title", categories = "tech", comment = "Comment")
     advanceUntilIdle()
 
-    viewModel.updateUrl("other.com/different")
+    viewModel.resetForm()
     advanceUntilIdle()
 
     val state = viewModel.uiState.first()
-    assertEquals("url should remain unchanged", "example.com/article", state.url)
+    assertFalse("isEditMode should be false", state.isEditMode)
+    assertEquals("url should be empty", "", state.url)
+    assertEquals("title should be empty", "", state.title)
+    assertEquals("categories should be empty", "", state.categories)
+    assertEquals("comment should be empty", "", state.comment)
   }
 
   @Test

--- a/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
@@ -306,7 +306,7 @@ class PostBookmarkViewModelTest {
     viewModel.initializeForEdit(
         url = "example.com/article",
         title = "Existing Title",
-        categories = "tech, kotlin",
+        categories = listOf("tech", "kotlin"),
         comment = "Existing comment")
     advanceUntilIdle()
 
@@ -321,7 +321,10 @@ class PostBookmarkViewModelTest {
   @Test
   fun `resetForm should clear edit mode and all fields`() = runTest {
     viewModel.initializeForEdit(
-        url = "example.com/article", title = "Title", categories = "tech", comment = "Comment")
+        url = "example.com/article",
+        title = "Title",
+        categories = listOf("tech"),
+        comment = "Comment")
     advanceUntilIdle()
 
     viewModel.resetForm()
@@ -353,7 +356,7 @@ class PostBookmarkViewModelTest {
     viewModel.initializeForEdit(
         url = "example.com/article",
         title = "Original Title",
-        categories = "tech",
+        categories = listOf("tech"),
         comment = "Original comment")
     viewModel.updateTitle("Updated Title")
     viewModel.updateComment("Updated comment")

--- a/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
@@ -328,6 +328,39 @@ class PostBookmarkViewModelTest {
   }
 
   @Test
+  fun `prepareSignEventIntent in edit mode should use original URL`() = runTest {
+    val realEvent =
+        UnsignedNostrEvent(
+            pubkey = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+            createdAt = 1_234_567_890,
+            kind = 39701,
+            tags = listOf(listOf("d", "example.com/article")),
+            content = "Updated comment")
+    val mockIntent = mockk<Intent>()
+
+    coEvery { postBookmarkUseCase.createUnsignedEvent(any(), any(), any(), any()) } returns
+        Result.success(realEvent)
+    every { nip55SignerClient.createSignEventIntent(any()) } returns mockIntent
+
+    viewModel.initializeForEdit(
+        url = "example.com/article",
+        title = "Original Title",
+        categories = "tech",
+        comment = "Original comment")
+    viewModel.updateTitle("Updated Title")
+    viewModel.updateComment("Updated comment")
+    advanceUntilIdle()
+
+    viewModel.prepareSignEventIntent {}
+    advanceUntilIdle()
+
+    coVerify {
+      postBookmarkUseCase.createUnsignedEvent(
+          "example.com/article", "Updated Title", any(), "Updated comment")
+    }
+  }
+
+  @Test
   fun `prepareSignEventIntent should parse categories correctly`() = runTest {
     val realEvent =
         UnsignedNostrEvent(

--- a/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
@@ -311,6 +311,23 @@ class PostBookmarkViewModelTest {
   }
 
   @Test
+  fun `initializeForEdit should set edit mode with existing values`() = runTest {
+    viewModel.initializeForEdit(
+        url = "example.com/article",
+        title = "Existing Title",
+        categories = "tech, kotlin",
+        comment = "Existing comment")
+    advanceUntilIdle()
+
+    val state = viewModel.uiState.first()
+    assertTrue("isEditMode should be true", state.isEditMode)
+    assertEquals("url should be set", "example.com/article", state.url)
+    assertEquals("title should be set", "Existing Title", state.title)
+    assertEquals("categories should be set", "tech, kotlin", state.categories)
+    assertEquals("comment should be set", "Existing comment", state.comment)
+  }
+
+  @Test
   fun `prepareSignEventIntent should parse categories correctly`() = runTest {
     val realEvent =
         UnsignedNostrEvent(

--- a/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
@@ -328,6 +328,19 @@ class PostBookmarkViewModelTest {
   }
 
   @Test
+  fun `updateUrl should be ignored in edit mode`() = runTest {
+    viewModel.initializeForEdit(
+        url = "example.com/article", title = "Title", categories = "tech", comment = "Comment")
+    advanceUntilIdle()
+
+    viewModel.updateUrl("other.com/different")
+    advanceUntilIdle()
+
+    val state = viewModel.uiState.first()
+    assertEquals("url should remain unchanged", "example.com/article", state.url)
+  }
+
+  @Test
   fun `prepareSignEventIntent in edit mode should use original URL`() = runTest {
     val realEvent =
         UnsignedNostrEvent(


### PR DESCRIPTION
## Summary

Allow users to edit their own kind 39701 bookmark events by modifying the title, categories, and comment.

## Details

Kind 39701 is a parameterized replaceable event in Nostr. Publishing a new event with the same d-tag automatically replaces the previous version on relays. This PR leverages that behavior by reusing the existing PostBookmarkScreen for editing.

An edit button is added to the BookmarkDetailScreen top bar, visible only when the displayed bookmark's author pubkey matches the logged-in user. The edit screen pre-populates existing values and keeps the URL field read-only to ensure the d-tag remains unchanged.

## Confirmation

- Edit icon appears on BookmarkDetailScreen only for the user's own bookmarks
- Edit icon is hidden for other users' bookmarks and in read-only mode
- URL field is disabled in edit mode
- Screen title shows "Edit Bookmark" instead of "Add Bookmark"
- Title, categories, and comment can be modified and republished

## Limitation

- URL cannot be changed during editing because it would alter the d-tag, effectively creating a new bookmark rather than replacing the existing one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bookmark edit mode with prefilled edit flow and category preservation
  * Edit button appears on bookmark detail when editing is allowed
  * Form title switches between edit and create modes; URL field is read-only in edit mode
  * Japanese localization added for edit UI

* **Tests**
  * Added UI and unit tests covering bookmark detail and post-bookmark edit behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->