### PR TITLE
refactor: extract Nostr tag keys to NIP-scoped constants

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -444,7 +444,7 @@ fun PinosuApp(
                 val loadComments = {
                   detailViewModel.loadComments(
                       rootPubkey = route.authorPubkey,
-                      dTag = route.dTag,
+                      identifier = route.identifier,
                       rootEventId = route.eventId,
                       authorContent = route.content,
                       authorCreatedAt = route.createdAt)
@@ -472,7 +472,7 @@ fun PinosuApp(
                     onPostComment = {
                       detailViewModel.prepareSignCommentIntent(
                           rootPubkey = route.authorPubkey,
-                          dTag = route.dTag,
+                          identifier = route.identifier,
                           rootEventId = route.eventId) { intent ->
                             intent?.let { signCommentLauncher.launch(it) }
                           }
@@ -489,7 +489,7 @@ fun PinosuApp(
                             {
                               navController.navigate(
                                   PostBookmark(
-                                      editUrl = route.dTag,
+                                      editUrl = route.identifier,
                                       editTitle = route.title,
                                       editCategories = route.categories,
                                       editComment = route.content,
@@ -560,7 +560,7 @@ private fun navigateToBookmarkDetail(
     bookmark: io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem,
 ) {
   val event = bookmark.event ?: return
-  val dTag =
+  val identifier =
       event.tags.firstOrNull { it.isNotEmpty() && it[0] == NipB0.Tag.IDENTIFIER }?.getOrNull(1)
           ?: return
   val eventId = bookmark.eventId ?: return
@@ -569,7 +569,7 @@ private fun navigateToBookmarkDetail(
       BookmarkDetail(
           eventId = eventId,
           authorPubkey = event.author,
-          dTag = dTag,
+          identifier = identifier,
           title = bookmark.title,
           content = event.content,
           createdAt = event.createdAt,

--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -52,6 +52,7 @@ import io.github.omochice.pinosu.core.navigation.defaultExitTransition
 import io.github.omochice.pinosu.core.navigation.defaultPopEnterTransition
 import io.github.omochice.pinosu.core.navigation.defaultPopExitTransition
 import io.github.omochice.pinosu.core.nip.nip55.Nip55SignerClient
+import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import io.github.omochice.pinosu.feature.appinfo.presentation.model.AppInfoUiState
 import io.github.omochice.pinosu.feature.appinfo.presentation.ui.AppInfoScreen
 import io.github.omochice.pinosu.feature.auth.presentation.ui.LoginScreen
@@ -559,9 +560,11 @@ private fun navigateToBookmarkDetail(
     bookmark: io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem,
 ) {
   val event = bookmark.event ?: return
-  val dTag = event.tags.firstOrNull { it.isNotEmpty() && it[0] == "d" }?.getOrNull(1) ?: return
+  val dTag =
+      event.tags.firstOrNull { it.isNotEmpty() && it[0] == NipB0.Tag.IDENTIFIER }?.getOrNull(1)
+          ?: return
   val eventId = bookmark.eventId ?: return
-  val categories = event.tags.filter { it.size >= 2 && it[0] == "t" }.map { it[1] }
+  val categories = event.tags.filter { it.size >= 2 && it[0] == NipB0.Tag.CATEGORY }.map { it[1] }
   navController.navigate(
       BookmarkDetail(
           eventId = eventId,

--- a/app/src/main/java/io/github/omochice/pinosu/core/navigation/Navigation.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/navigation/Navigation.kt
@@ -44,7 +44,7 @@ data class PostBookmark(
  *
  * @property eventId Event ID of the kind 39701 bookmark
  * @property authorPubkey Hex-encoded public key of the bookmark author
- * @property dTag The d-tag of the bookmark event (URL without scheme)
+ * @property identifier The bookmark identifier (URL without scheme)
  * @property title Bookmark title, or null if not available
  * @property content Bookmark event content (author's comment)
  * @property createdAt Unix timestamp of the bookmark event
@@ -56,7 +56,7 @@ data class PostBookmark(
 data class BookmarkDetail(
     val eventId: String,
     val authorPubkey: String,
-    val dTag: String,
+    val identifier: String,
     val title: String? = null,
     val content: String = "",
     val createdAt: Long = 0L,

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip22/Nip22.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip22/Nip22.kt
@@ -3,4 +3,17 @@ package io.github.omochice.pinosu.core.nip.nip22
 /** NIP-22 protocol constants for comments */
 object Nip22 {
   const val KIND_COMMENT = 1111
+
+  /** Tag keys used in kind 1111 comment events */
+  object Tag {
+    const val ADDRESS = "a"
+    const val EVENT = "e"
+    const val KIND = "k"
+    const val PUBKEY = "p"
+
+    const val ADDRESS_ROOT = "A"
+    const val EVENT_ROOT = "E"
+    const val KIND_ROOT = "K"
+    const val PUBKEY_ROOT = "P"
+  }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip65/Nip65.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip65/Nip65.kt
@@ -1,0 +1,10 @@
+package io.github.omochice.pinosu.core.nip.nip65
+
+/** NIP-65 protocol constants for relay list metadata */
+object Nip65 {
+
+  /** Tag keys used in kind 10002 relay list metadata events */
+  object Tag {
+    const val RELAY = "r"
+  }
+}

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip65/Nip65EventParser.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip65/Nip65EventParser.kt
@@ -31,7 +31,7 @@ class Nip65EventParserImpl @Inject constructor() : Nip65EventParser {
     }
 
     return event.tags
-        .filter { tag -> tag.size >= 2 && tag[0] == TAG_RELAY }
+        .filter { tag -> tag.size >= 2 && tag[0] == Nip65.Tag.RELAY }
         .mapNotNull { tag -> parseRelayTag(tag) }
   }
 
@@ -68,7 +68,6 @@ class Nip65EventParserImpl @Inject constructor() : Nip65EventParser {
     /** NIP-65 Relay List Metadata event kind */
     const val KIND_RELAY_LIST_METADATA = 10002
 
-    private const val TAG_RELAY = "r"
     private const val MARKER_READ = "read"
     private const val MARKER_WRITE = "write"
   }

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip89/Nip89.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip89/Nip89.kt
@@ -4,6 +4,11 @@ package io.github.omochice.pinosu.core.nip.nip89
 object Nip89 {
   const val CLIENT_NAME = "Pinosu"
 
+  /** Tag keys used in NIP-89 client identification */
+  object Tag {
+    const val CLIENT = "client"
+  }
+
   /** Build a client tag for identifying this app in published events */
-  fun clientTag(): List<String> = listOf("client", CLIENT_NAME)
+  fun clientTag(): List<String> = listOf(Tag.CLIENT, CLIENT_NAME)
 }

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nipb0/NipB0.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nipb0/NipB0.kt
@@ -3,4 +3,12 @@ package io.github.omochice.pinosu.core.nip.nipb0
 /** NIP-B0 protocol constants for bookmark lists */
 object NipB0 {
   const val KIND_BOOKMARK_LIST = 39701
+
+  /** Tag keys used in kind 39701 bookmark events */
+  object Tag {
+    const val IDENTIFIER = "d"
+    const val CATEGORY = "t"
+    const val URL = "r"
+    const val TITLE = "title"
+  }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
@@ -147,14 +147,14 @@ constructor(
   }
 
   private suspend fun buildBookmarkItem(event: NostrEvent): BookmarkItem? {
-    val dTags =
+    val identifierUrls =
         event.tags
             .filter { it.isNotEmpty() && it[0] == NipB0.Tag.IDENTIFIER }
             .mapNotNull { it.getOrNull(1) }
             .map { "https://$it" }
             .filter { isValidUrl(it) }
 
-    val rTags =
+    val urlTags =
         event.tags
             .filter { it.isNotEmpty() && it[0] == NipB0.Tag.URL }
             .mapNotNull { it.getOrNull(1) }
@@ -162,8 +162,8 @@ constructor(
 
     val urls =
         when {
-          dTags.isNotEmpty() -> dTags
-          rTags.isNotEmpty() -> rTags
+          identifierUrls.isNotEmpty() -> identifierUrls
+          urlTags.isNotEmpty() -> urlTags
           else -> return null
         }
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
@@ -121,18 +121,18 @@ constructor(
           else -> rawUrl
         }
 
-    tags.add(listOf("d", normalizedUrl))
+    tags.add(listOf(NipB0.Tag.IDENTIFIER, normalizedUrl))
 
     if (title.isNotBlank()) {
-      tags.add(listOf("title", title))
+      tags.add(listOf(NipB0.Tag.TITLE, title))
     }
 
     categories
         .filter { it.isNotBlank() }
-        .forEach { category -> tags.add(listOf("t", category.trim())) }
+        .forEach { category -> tags.add(listOf(NipB0.Tag.CATEGORY, category.trim())) }
 
     val fullUrl = if (rawUrl != normalizedUrl) rawUrl else "$SCHEME_HTTPS$normalizedUrl"
-    tags.add(listOf("r", fullUrl))
+    tags.add(listOf(NipB0.Tag.URL, fullUrl))
 
     if (clientTagRepository.clientTagEnabledFlow.value) {
       tags.add(Nip89.clientTag())
@@ -149,14 +149,14 @@ constructor(
   private suspend fun buildBookmarkItem(event: NostrEvent): BookmarkItem? {
     val dTags =
         event.tags
-            .filter { it.isNotEmpty() && it[0] == "d" }
+            .filter { it.isNotEmpty() && it[0] == NipB0.Tag.IDENTIFIER }
             .mapNotNull { it.getOrNull(1) }
             .map { "https://$it" }
             .filter { isValidUrl(it) }
 
     val rTags =
         event.tags
-            .filter { it.isNotEmpty() && it[0] == "r" }
+            .filter { it.isNotEmpty() && it[0] == NipB0.Tag.URL }
             .mapNotNull { it.getOrNull(1) }
             .filter { isValidUrl(it) }
 
@@ -167,7 +167,7 @@ constructor(
           else -> return null
         }
 
-    val titleTag = event.tags.firstOrNull { it.size >= 2 && it[0] == "title" }?.get(1)
+    val titleTag = event.tags.firstOrNull { it.size >= 2 && it[0] == NipB0.Tag.TITLE }?.get(1)
     val metadata = urlMetadataFetcher.fetchMetadata(urls.first()).getOrNull()
     val title = titleTag ?: metadata?.title
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -49,12 +49,12 @@ constructor(
 
   override suspend fun getCommentsForBookmark(
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String
   ): Result<List<Comment>> {
     return try {
       val relays = relayListProvider.getRelays()
-      val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$dTag"
+      val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$identifier"
       val filter =
           Json.encodeToString(
               CommentFilter(
@@ -89,10 +89,10 @@ constructor(
       hexPubkey: String,
       content: String,
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String
   ): UnsignedNostrEvent {
-    val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$dTag"
+    val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$identifier"
 
     val tags = buildList {
       add(listOf(Nip22.Tag.ADDRESS_ROOT, addressTagValue))

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -95,14 +95,14 @@ constructor(
     val aTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$dTag"
 
     val tags = buildList {
-      add(listOf("A", aTagValue))
-      add(listOf("E", rootEventId))
-      add(listOf("K", NipB0.KIND_BOOKMARK_LIST.toString()))
-      add(listOf("P", rootPubkey))
-      add(listOf("a", aTagValue))
-      add(listOf("e", rootEventId))
-      add(listOf("k", NipB0.KIND_BOOKMARK_LIST.toString()))
-      add(listOf("p", rootPubkey))
+      add(listOf(Nip22.Tag.ADDRESS_ROOT, aTagValue))
+      add(listOf(Nip22.Tag.EVENT_ROOT, rootEventId))
+      add(listOf(Nip22.Tag.KIND_ROOT, NipB0.KIND_BOOKMARK_LIST.toString()))
+      add(listOf(Nip22.Tag.PUBKEY_ROOT, rootPubkey))
+      add(listOf(Nip22.Tag.ADDRESS, aTagValue))
+      add(listOf(Nip22.Tag.EVENT, rootEventId))
+      add(listOf(Nip22.Tag.KIND, NipB0.KIND_BOOKMARK_LIST.toString()))
+      add(listOf(Nip22.Tag.PUBKEY, rootPubkey))
       if (clientTagRepository.clientTagEnabledFlow.value) {
         add(Nip89.clientTag())
       }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -54,12 +54,12 @@ constructor(
   ): Result<List<Comment>> {
     return try {
       val relays = relayListProvider.getRelays()
-      val aTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$dTag"
+      val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$dTag"
       val filter =
           Json.encodeToString(
               CommentFilter(
                   kinds = listOf(Nip22.KIND_COMMENT),
-                  aTag = listOf(aTagValue),
+                  aTag = listOf(addressTagValue),
                   eTag = listOf(rootEventId),
               ))
 
@@ -92,14 +92,14 @@ constructor(
       dTag: String,
       rootEventId: String
   ): UnsignedNostrEvent {
-    val aTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$dTag"
+    val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$dTag"
 
     val tags = buildList {
-      add(listOf(Nip22.Tag.ADDRESS_ROOT, aTagValue))
+      add(listOf(Nip22.Tag.ADDRESS_ROOT, addressTagValue))
       add(listOf(Nip22.Tag.EVENT_ROOT, rootEventId))
       add(listOf(Nip22.Tag.KIND_ROOT, NipB0.KIND_BOOKMARK_LIST.toString()))
       add(listOf(Nip22.Tag.PUBKEY_ROOT, rootPubkey))
-      add(listOf(Nip22.Tag.ADDRESS, aTagValue))
+      add(listOf(Nip22.Tag.ADDRESS, addressTagValue))
       add(listOf(Nip22.Tag.EVENT, rootEventId))
       add(listOf(Nip22.Tag.KIND, NipB0.KIND_BOOKMARK_LIST.toString()))
       add(listOf(Nip22.Tag.PUBKEY, rootPubkey))

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/repository/CommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/repository/CommentRepository.kt
@@ -16,13 +16,13 @@ interface CommentRepository {
    * Fetch kind 1111 comments for a kind 39701 bookmark event
    *
    * @param rootPubkey Hex-encoded public key of the bookmark author
-   * @param dTag The d-tag of the bookmark event (URL without scheme)
+   * @param identifier The bookmark identifier (URL without scheme)
    * @param rootEventId The event ID of the bookmark event
    * @return Result containing list of Comments on success or error on failure
    */
   suspend fun getCommentsForBookmark(
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String
   ): Result<List<Comment>>
 
@@ -40,7 +40,7 @@ interface CommentRepository {
    * @param hexPubkey Author's public key (hex-encoded)
    * @param content Comment text
    * @param rootPubkey Hex-encoded public key of the bookmark author
-   * @param dTag The d-tag of the bookmark event
+   * @param identifier The bookmark identifier
    * @param rootEventId The event ID of the bookmark event
    * @return Unsigned event ready for NIP-55 signing
    */
@@ -48,7 +48,7 @@ interface CommentRepository {
       hexPubkey: String,
       content: String,
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String
   ): UnsignedNostrEvent
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCase.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCase.kt
@@ -16,7 +16,7 @@ interface GetCommentsForBookmarkUseCase {
    * comments are sorted by createdAt ascending.
    *
    * @param rootPubkey Hex-encoded public key of the bookmark author
-   * @param dTag The d-tag of the bookmark event
+   * @param identifier The bookmark identifier
    * @param rootEventId The event ID of the bookmark event
    * @param authorContent The bookmark event's content field (may be empty)
    * @param authorCreatedAt The bookmark event's created_at timestamp
@@ -24,7 +24,7 @@ interface GetCommentsForBookmarkUseCase {
    */
   suspend operator fun invoke(
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String,
       authorContent: String,
       authorCreatedAt: Long,

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseImpl.kt
@@ -23,12 +23,12 @@ constructor(
 
   override suspend fun invoke(
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String,
       authorContent: String,
       authorCreatedAt: Long,
   ): Result<List<Comment>> {
-    val relayResult = commentRepository.getCommentsForBookmark(rootPubkey, dTag, rootEventId)
+    val relayResult = commentRepository.getCommentsForBookmark(rootPubkey, identifier, rootEventId)
     val relayComments =
         relayResult.getOrElse {
           return Result.failure(it)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/PostCommentUseCase.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/PostCommentUseCase.kt
@@ -15,14 +15,14 @@ interface PostCommentUseCase {
    *
    * @param content Comment text
    * @param rootPubkey Hex-encoded public key of the bookmark author
-   * @param dTag The d-tag of the bookmark event
+   * @param identifier The bookmark identifier
    * @param rootEventId The event ID of the bookmark event
    * @return Result containing unsigned event on success or error on failure
    */
   suspend fun createUnsignedEvent(
       content: String,
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String,
   ): Result<UnsignedNostrEvent>
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/PostCommentUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/PostCommentUseCaseImpl.kt
@@ -24,7 +24,7 @@ constructor(
   override suspend fun createUnsignedEvent(
       content: String,
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String,
   ): Result<UnsignedNostrEvent> {
     val user =
@@ -38,7 +38,7 @@ constructor(
             hexPubkey = hexPubkey,
             content = content,
             rootPubkey = rootPubkey,
-            dTag = dTag,
+            identifier = identifier,
             rootEventId = rootEventId))
   }
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/viewmodel/BookmarkDetailViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/viewmodel/BookmarkDetailViewModel.kt
@@ -44,14 +44,14 @@ constructor(
    * Load comments for a bookmark event
    *
    * @param rootPubkey Hex-encoded public key of the bookmark author
-   * @param dTag The d-tag of the bookmark event
+   * @param identifier The bookmark identifier
    * @param rootEventId The event ID of the bookmark event
    * @param authorContent The bookmark event's content field
    * @param authorCreatedAt The bookmark event's created_at timestamp
    */
   fun loadComments(
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String,
       authorContent: String,
       authorCreatedAt: Long,
@@ -61,7 +61,7 @@ constructor(
     viewModelScope.launch {
       getCommentsUseCase(
               rootPubkey = rootPubkey,
-              dTag = dTag,
+              identifier = identifier,
               rootEventId = rootEventId,
               authorContent = authorContent,
               authorCreatedAt = authorCreatedAt)
@@ -96,13 +96,13 @@ constructor(
    * Prepare sign comment Intent for NIP-55 signer
    *
    * @param rootPubkey Hex-encoded public key of the bookmark author
-   * @param dTag The d-tag of the bookmark event
+   * @param identifier The bookmark identifier
    * @param rootEventId The event ID of the bookmark event
    * @param onReady Callback with Intent when ready, or null on failure
    */
   fun prepareSignCommentIntent(
       rootPubkey: String,
-      dTag: String,
+      identifier: String,
       rootEventId: String,
       onReady: (Intent?) -> Unit,
   ) {
@@ -119,7 +119,10 @@ constructor(
     viewModelScope.launch {
       postCommentUseCase
           .createUnsignedEvent(
-              content = content, rootPubkey = rootPubkey, dTag = dTag, rootEventId = rootEventId)
+              content = content,
+              rootPubkey = rootPubkey,
+              identifier = identifier,
+              rootEventId = rootEventId)
           .onSuccess { unsignedEvent ->
             pendingUnsignedEvent = unsignedEvent
             val eventJson = unsignedEvent.toJson()

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip22/Nip22TagTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip22/Nip22TagTest.kt
@@ -1,0 +1,47 @@
+package io.github.omochice.pinosu.core.nip.nip22
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class Nip22TagTest {
+
+  @Test
+  fun `ADDRESS equals a`() {
+    assertEquals("a", Nip22.Tag.ADDRESS)
+  }
+
+  @Test
+  fun `EVENT equals e`() {
+    assertEquals("e", Nip22.Tag.EVENT)
+  }
+
+  @Test
+  fun `KIND equals k`() {
+    assertEquals("k", Nip22.Tag.KIND)
+  }
+
+  @Test
+  fun `PUBKEY equals p`() {
+    assertEquals("p", Nip22.Tag.PUBKEY)
+  }
+
+  @Test
+  fun `ADDRESS_ROOT equals A`() {
+    assertEquals("A", Nip22.Tag.ADDRESS_ROOT)
+  }
+
+  @Test
+  fun `EVENT_ROOT equals E`() {
+    assertEquals("E", Nip22.Tag.EVENT_ROOT)
+  }
+
+  @Test
+  fun `KIND_ROOT equals K`() {
+    assertEquals("K", Nip22.Tag.KIND_ROOT)
+  }
+
+  @Test
+  fun `PUBKEY_ROOT equals P`() {
+    assertEquals("P", Nip22.Tag.PUBKEY_ROOT)
+  }
+}

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip65/Nip65TagTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip65/Nip65TagTest.kt
@@ -1,0 +1,12 @@
+package io.github.omochice.pinosu.core.nip.nip65
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class Nip65TagTest {
+
+  @Test
+  fun `RELAY equals r`() {
+    assertEquals("r", Nip65.Tag.RELAY)
+  }
+}

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip89/Nip89Test.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip89/Nip89Test.kt
@@ -11,4 +11,9 @@ class Nip89Test {
 
     assertEquals(listOf("client", "Pinosu"), tag)
   }
+
+  @Test
+  fun `Tag CLIENT equals client`() {
+    assertEquals("client", Nip89.Tag.CLIENT)
+  }
 }

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nipb0/NipB0TagTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nipb0/NipB0TagTest.kt
@@ -1,0 +1,27 @@
+package io.github.omochice.pinosu.core.nip.nipb0
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NipB0TagTest {
+
+  @Test
+  fun `IDENTIFIER equals d`() {
+    assertEquals("d", NipB0.Tag.IDENTIFIER)
+  }
+
+  @Test
+  fun `CATEGORY equals t`() {
+    assertEquals("t", NipB0.Tag.CATEGORY)
+  }
+
+  @Test
+  fun `URL equals r`() {
+    assertEquals("r", NipB0.Tag.URL)
+  }
+
+  @Test
+  fun `TITLE equals title`() {
+    assertEquals("title", NipB0.Tag.TITLE)
+  }
+}

--- a/app/src/test/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepositoryTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepositoryTest.kt
@@ -55,7 +55,7 @@ class RelayCommentRepositoryTest {
 
     val result =
         repository.getCommentsForBookmark(
-            rootPubkey = "abc123", dTag = "example.com/article", rootEventId = "event123")
+            rootPubkey = "abc123", identifier = "example.com/article", rootEventId = "event123")
 
     assertTrue(result.isSuccess)
     assertTrue(result.getOrNull()!!.isEmpty())
@@ -82,7 +82,7 @@ class RelayCommentRepositoryTest {
 
     val result =
         repository.getCommentsForBookmark(
-            rootPubkey = "abc123", dTag = "example.com/article", rootEventId = "event123")
+            rootPubkey = "abc123", identifier = "example.com/article", rootEventId = "event123")
 
     assertTrue(result.isSuccess)
     val comments = result.getOrNull()!!
@@ -100,7 +100,7 @@ class RelayCommentRepositoryTest {
         emptyList()
 
     repository.getCommentsForBookmark(
-        rootPubkey = "abc123", dTag = "example.com/article", rootEventId = "event123")
+        rootPubkey = "abc123", identifier = "example.com/article", rootEventId = "event123")
 
     val filter = filterSlot.captured
     assertTrue(filter.contains("\"kinds\":[1111]"))
@@ -115,7 +115,7 @@ class RelayCommentRepositoryTest {
             hexPubkey = "my-pubkey",
             content = "My comment",
             rootPubkey = "root-pubkey",
-            dTag = "example.com/article",
+            identifier = "example.com/article",
             rootEventId = "root-event-id")
 
     assertEquals(1111, event.kind)
@@ -192,7 +192,7 @@ class RelayCommentRepositoryTest {
             hexPubkey = "my-pubkey",
             content = "My comment",
             rootPubkey = "root-pubkey",
-            dTag = "example.com/article",
+            identifier = "example.com/article",
             rootEventId = "root-event-id")
 
     val clientTags = event.tags.filter { it.isNotEmpty() && it[0] == "client" }
@@ -209,7 +209,7 @@ class RelayCommentRepositoryTest {
             hexPubkey = "my-pubkey",
             content = "My comment",
             rootPubkey = "root-pubkey",
-            dTag = "example.com/article",
+            identifier = "example.com/article",
             rootEventId = "root-event-id")
 
     val clientTags = event.tags.filter { it.isNotEmpty() && it[0] == "client" }

--- a/app/src/test/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseTest.kt
@@ -51,7 +51,7 @@ class GetCommentsForBookmarkUseCaseTest {
     val result =
         useCase(
             rootPubkey = "root-pubkey",
-            dTag = "d-tag",
+            identifier = "d-tag",
             rootEventId = "event-id",
             authorContent = "My bookmark note",
             authorCreatedAt = 1_700_000_000L)
@@ -78,7 +78,7 @@ class GetCommentsForBookmarkUseCaseTest {
     val result =
         useCase(
             rootPubkey = "root-pubkey",
-            dTag = "d-tag",
+            identifier = "d-tag",
             rootEventId = "event-id",
             authorContent = "",
             authorCreatedAt = 1_700_000_000L)
@@ -102,7 +102,7 @@ class GetCommentsForBookmarkUseCaseTest {
     val result =
         useCase(
             rootPubkey = "root-pubkey",
-            dTag = "d-tag",
+            identifier = "d-tag",
             rootEventId = "event-id",
             authorContent = "",
             authorCreatedAt = 1_700_000_000L)
@@ -141,7 +141,7 @@ class GetCommentsForBookmarkUseCaseTest {
         val result =
             useCase(
                 rootPubkey = "root-pubkey",
-                dTag = "d-tag",
+                identifier = "d-tag",
                 rootEventId = "event-id",
                 authorContent = authorContent,
                 authorCreatedAt = 1_700_000_000L)

--- a/app/src/test/java/io/github/omochice/pinosu/feature/comment/domain/usecase/PostCommentUseCaseTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/comment/domain/usecase/PostCommentUseCaseTest.kt
@@ -44,7 +44,7 @@ class PostCommentUseCaseTest {
         useCase.createUnsignedEvent(
             content = "My comment",
             rootPubkey = "root-pubkey",
-            dTag = "example.com/article",
+            identifier = "example.com/article",
             rootEventId = "event-123")
 
     assertTrue(result.isFailure)
@@ -69,7 +69,7 @@ class PostCommentUseCaseTest {
           hexPubkey = any(),
           content = "My comment",
           rootPubkey = "root-pubkey",
-          dTag = "example.com/article",
+          identifier = "example.com/article",
           rootEventId = "event-123")
     } returns expectedEvent
 
@@ -77,7 +77,7 @@ class PostCommentUseCaseTest {
         useCase.createUnsignedEvent(
             content = "My comment",
             rootPubkey = "root-pubkey",
-            dTag = "example.com/article",
+            identifier = "example.com/article",
             rootEventId = "event-123")
 
     assertTrue(result.isSuccess)
@@ -87,7 +87,7 @@ class PostCommentUseCaseTest {
           hexPubkey = any(),
           content = "My comment",
           rootPubkey = "root-pubkey",
-          dTag = "example.com/article",
+          identifier = "example.com/article",
           rootEventId = "event-123")
     }
   }

--- a/app/src/test/java/io/github/omochice/pinosu/feature/comment/presentation/viewmodel/BookmarkDetailViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/comment/presentation/viewmodel/BookmarkDetailViewModelTest.kt
@@ -87,7 +87,7 @@ class BookmarkDetailViewModelTest {
         coEvery {
           getCommentsUseCase(
               rootPubkey = "author-pk",
-              dTag = "example.com",
+              identifier = "example.com",
               rootEventId = "evt-1",
               authorContent = "My note",
               authorCreatedAt = 1_699_999_999L)
@@ -95,7 +95,7 @@ class BookmarkDetailViewModelTest {
 
         viewModel.loadComments(
             rootPubkey = "author-pk",
-            dTag = "example.com",
+            identifier = "example.com",
             rootEventId = "evt-1",
             authorContent = "My note",
             authorCreatedAt = 1_699_999_999L)
@@ -115,7 +115,7 @@ class BookmarkDetailViewModelTest {
 
         viewModel.loadComments(
             rootPubkey = "pk",
-            dTag = "d",
+            identifier = "d",
             rootEventId = "e",
             authorContent = "",
             authorCreatedAt = 0L)
@@ -146,7 +146,7 @@ class BookmarkDetailViewModelTest {
 
         viewModel.loadComments(
             rootPubkey = "author-pk",
-            dTag = "example.com",
+            identifier = "example.com",
             rootEventId = "evt-1",
             authorContent = "Author note",
             authorCreatedAt = 1_699_999_999L)
@@ -184,7 +184,7 @@ class BookmarkDetailViewModelTest {
           postCommentUseCase.createUnsignedEvent(
               content = "My comment",
               rootPubkey = "root-pk",
-              dTag = "example.com",
+              identifier = "example.com",
               rootEventId = "evt-1")
         } returns Result.success(unsignedEvent)
         every { nip55SignerClient.createSignEventIntent(any()) } returns mockIntent
@@ -194,7 +194,7 @@ class BookmarkDetailViewModelTest {
 
         var receivedIntent: Intent? = null
         viewModel.prepareSignCommentIntent(
-            rootPubkey = "root-pk", dTag = "example.com", rootEventId = "evt-1") {
+            rootPubkey = "root-pk", identifier = "example.com", rootEventId = "evt-1") {
               receivedIntent = it
             }
         advanceUntilIdle()
@@ -290,7 +290,7 @@ class BookmarkDetailViewModelTest {
 
         viewModel.loadComments(
             rootPubkey = "author-pk",
-            dTag = "example.com",
+            identifier = "example.com",
             rootEventId = "evt-1",
             authorContent = "",
             authorCreatedAt = 0L)


### PR DESCRIPTION
## Summary

Replace raw Nostr tag key string literals with NIP-scoped `Tag` object constants, and rename related variables and parameters to reflect their semantic meaning.

## Details

Nostr event tag keys (`"d"`, `"t"`, `"r"`, `"title"`, etc.) were scattered as raw string literals across the codebase. This "stringly-typed" pattern is prone to silent typos and obscures the fact that the same letter can carry different semantics depending on the event kind.

Rather than a single flat `NostrTagKey` object, each NIP protocol object now owns a nested `Tag` object that names its keys by meaning rather than by letter:

- `NipB0.Tag`: `IDENTIFIER`, `CATEGORY`, `URL`, `TITLE` (kind 39701 bookmarks)
- `Nip22.Tag`: `ADDRESS`, `EVENT`, `KIND`, `PUBKEY` and their `_ROOT` variants (kind 1111 comments)
- `Nip65.Tag`: `RELAY` (kind 10002 relay list metadata)
- `Nip89.Tag`: `CLIENT` (client identification)

Variable and parameter names that referenced the old tag letter (`dTag`, `aTagValue`, `dTags`, `rTags`) were also renamed to match their semantic meaning (`identifier`, `addressTagValue`, `identifierUrls`, `urlTags`).

## Confirmation

- All existing unit tests pass without modification (aside from the parameter renames).
- `detekt` reports no new violations.
- New tests verify each `Tag` constant value.

## Limitation

No known limitations.

Closes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored bookmark handling to consistently use "identifier" terminology throughout the app, improving standards alignment.
  * Added standardized NIP tag constants (NipB0, Nip22, Nip65, Nip89) to replace hardcoded string values, enhancing protocol compliance and code maintainability.
  * Updated comment creation and retrieval to seamlessly integrate with the new identifier system.

* **Tests**
  * Added comprehensive test coverage for NIP tag constants to ensure protocol compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->