### PR TITLE
fix: remove #E tag filter from comment query

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nipb0/NipB0.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nipb0/NipB0.kt
@@ -4,6 +4,16 @@ package io.github.omochice.pinosu.core.nip.nipb0
 object NipB0 {
   const val KIND_BOOKMARK_LIST = 39701
 
+  /**
+   * Create a NIP-33 address string for a bookmark list
+   *
+   * @param pubkey Hex-encoded public key of the author
+   * @param identifier The bookmark identifier (d-tag value)
+   * @return Address string in the format "kind:pubkey:identifier"
+   */
+  fun createAddress(pubkey: String, identifier: String): String =
+      "$KIND_BOOKMARK_LIST:$pubkey:$identifier"
+
   /** Tag keys used in kind 39701 bookmark events */
   object Tag {
     const val IDENTIFIER = "d"

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -24,7 +24,6 @@ import kotlinx.serialization.json.Json
 private data class CommentFilter(
     val kinds: List<Int>,
     @SerialName("#A") val aTag: List<String>,
-    @SerialName("#E") val eTag: List<String>,
 )
 
 @Serializable
@@ -50,7 +49,6 @@ constructor(
   override suspend fun getCommentsForBookmark(
       rootPubkey: String,
       identifier: String,
-      rootEventId: String
   ): Result<List<Comment>> {
     return try {
       val relays = relayListProvider.getRelays()
@@ -60,7 +58,6 @@ constructor(
               CommentFilter(
                   kinds = listOf(Nip22.KIND_COMMENT),
                   aTag = listOf(addressTagValue),
-                  eTag = listOf(rootEventId),
               ))
 
       val events = relayPool.subscribeWithTimeout(relays, filter, RelayPool.PER_RELAY_TIMEOUT_MS)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -92,7 +92,11 @@ constructor(
       identifier: String,
       rootEventId: String
   ): UnsignedNostrEvent {
+<<<<<<< HEAD
     val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$identifier"
+=======
+    val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$dTag"
+>>>>>>> 050cc419 (refactor: rename aTagValue to addressTagValue in RelayCommentRepository)
 
     val tags = buildList {
       add(listOf(Nip22.Tag.ADDRESS_ROOT, addressTagValue))

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -92,11 +92,7 @@ constructor(
       identifier: String,
       rootEventId: String
   ): UnsignedNostrEvent {
-<<<<<<< HEAD
     val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$identifier"
-=======
-    val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$dTag"
->>>>>>> 050cc419 (refactor: rename aTagValue to addressTagValue in RelayCommentRepository)
 
     val tags = buildList {
       add(listOf(Nip22.Tag.ADDRESS_ROOT, addressTagValue))

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -54,7 +54,7 @@ constructor(
   ): Result<List<Comment>> {
     return try {
       val relays = relayListProvider.getRelays()
-      val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$identifier"
+      val addressTagValue = NipB0.createAddress(rootPubkey, identifier)
       val filter =
           Json.encodeToString(
               CommentFilter(
@@ -92,7 +92,7 @@ constructor(
       identifier: String,
       rootEventId: String
   ): UnsignedNostrEvent {
-    val addressTagValue = "${NipB0.KIND_BOOKMARK_LIST}:$rootPubkey:$identifier"
+    val addressTagValue = NipB0.createAddress(rootPubkey, identifier)
 
     val tags = buildList {
       add(listOf(Nip22.Tag.ADDRESS_ROOT, addressTagValue))

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/repository/CommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/repository/CommentRepository.kt
@@ -15,15 +15,16 @@ interface CommentRepository {
   /**
    * Fetch kind 1111 comments for a kind 39701 bookmark event
    *
+   * Uses the NIP-33 address (kind:pubkey:identifier) to query comments, so that comments survive
+   * event replacement.
+   *
    * @param rootPubkey Hex-encoded public key of the bookmark author
    * @param identifier The bookmark identifier (URL without scheme)
-   * @param rootEventId The event ID of the bookmark event
    * @return Result containing list of Comments on success or error on failure
    */
   suspend fun getCommentsForBookmark(
       rootPubkey: String,
       identifier: String,
-      rootEventId: String
   ): Result<List<Comment>>
 
   /**

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseImpl.kt
@@ -28,7 +28,7 @@ constructor(
       authorContent: String,
       authorCreatedAt: Long,
   ): Result<List<Comment>> {
-    val relayResult = commentRepository.getCommentsForBookmark(rootPubkey, identifier, rootEventId)
+    val relayResult = commentRepository.getCommentsForBookmark(rootPubkey, identifier)
     val relayComments =
         relayResult.getOrElse {
           return Result.failure(it)

--- a/app/src/test/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepositoryTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepositoryTest.kt
@@ -54,8 +54,7 @@ class RelayCommentRepositoryTest {
     coEvery { relayPool.subscribeWithTimeout(any(), any(), any()) } returns emptyList()
 
     val result =
-        repository.getCommentsForBookmark(
-            rootPubkey = "abc123", identifier = "example.com/article", rootEventId = "event123")
+        repository.getCommentsForBookmark(rootPubkey = "abc123", identifier = "example.com/article")
 
     assertTrue(result.isSuccess)
     assertTrue(result.getOrNull()!!.isEmpty())
@@ -81,8 +80,7 @@ class RelayCommentRepositoryTest {
     coEvery { relayPool.subscribeWithTimeout(any(), any(), any()) } returns listOf(event)
 
     val result =
-        repository.getCommentsForBookmark(
-            rootPubkey = "abc123", identifier = "example.com/article", rootEventId = "event123")
+        repository.getCommentsForBookmark(rootPubkey = "abc123", identifier = "example.com/article")
 
     assertTrue(result.isSuccess)
     val comments = result.getOrNull()!!
@@ -99,13 +97,11 @@ class RelayCommentRepositoryTest {
     coEvery { relayPool.subscribeWithTimeout(any(), capture(filterSlot), any()) } returns
         emptyList()
 
-    repository.getCommentsForBookmark(
-        rootPubkey = "abc123", identifier = "example.com/article", rootEventId = "event123")
+    repository.getCommentsForBookmark(rootPubkey = "abc123", identifier = "example.com/article")
 
     val filter = filterSlot.captured
     assertTrue(filter.contains("\"kinds\":[1111]"))
     assertTrue(filter.contains(""""#A":["39701:abc123:example.com/article"]"""))
-    assertTrue(filter.contains(""""#E":["event123"]"""))
   }
 
   @Test

--- a/app/src/test/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseTest.kt
@@ -45,7 +45,7 @@ class GetCommentsForBookmarkUseCaseTest {
             authorPubkey = "other-pubkey",
             createdAt = 1_700_000_100L)
 
-    coEvery { commentRepository.getCommentsForBookmark("root-pubkey", "d-tag", "event-id") } returns
+    coEvery { commentRepository.getCommentsForBookmark("root-pubkey", "d-tag") } returns
         Result.success(listOf(relayComment))
 
     val result =
@@ -72,7 +72,7 @@ class GetCommentsForBookmarkUseCaseTest {
             authorPubkey = "other-pubkey",
             createdAt = 1_700_000_100L)
 
-    coEvery { commentRepository.getCommentsForBookmark("root-pubkey", "d-tag", "event-id") } returns
+    coEvery { commentRepository.getCommentsForBookmark("root-pubkey", "d-tag") } returns
         Result.success(listOf(relayComment))
 
     val result =
@@ -96,7 +96,7 @@ class GetCommentsForBookmarkUseCaseTest {
     val older =
         Comment(id = "older", content = "Older", authorPubkey = "p2", createdAt = 1_700_000_100L)
 
-    coEvery { commentRepository.getCommentsForBookmark("root-pubkey", "d-tag", "event-id") } returns
+    coEvery { commentRepository.getCommentsForBookmark("root-pubkey", "d-tag") } returns
         Result.success(listOf(newer, older))
 
     val result =
@@ -134,9 +134,8 @@ class GetCommentsForBookmarkUseCaseTest {
 
         coEvery { commentRepository.getEventsByIds(listOf(eventId)) } returns
             Result.success(listOf(fetchedEvent))
-        coEvery {
-          commentRepository.getCommentsForBookmark("root-pubkey", "d-tag", "event-id")
-        } returns Result.success(emptyList())
+        coEvery { commentRepository.getCommentsForBookmark("root-pubkey", "d-tag") } returns
+            Result.success(emptyList())
 
         val result =
             useCase(


### PR DESCRIPTION
## Summary

Remove the `#E` (event ID) tag from the comment fetch filter so that kind 1111 comments remain visible after a bookmark event is replaced.

## Details

The comment query filter previously required both `#A` (NIP-33 address) and `#E` (event ID) to match. When a kind 39701 bookmark event is replaced, the event ID changes while the address (kind:pubkey:identifier) remains stable. This caused comments attached to the previous event ID to become invisible. By filtering with `#A` only, comments now persist across event replacements, matching the behavior of other Nostr clients such as kuchiyose.

Also includes minor preparatory refactors already on this branch: extracting `NipB0.createAddress()` and renaming `aTagValue`/`dTag` parameters for clarity.

## Confirmation

- `./gradlew detekt test connectedAndroidTest` passes
- After replacing a kind 39701 event, kind 1111 comments attached to the previous version remain visible

## Limitation

No known limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)