### PR TITLE
fix: avoid OOM when bookmark URLs point to non-HTML resources

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/metadata/UrlMetadataFetcher.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/metadata/UrlMetadataFetcher.kt
@@ -55,9 +55,7 @@ class OkHttpUrlMetadataFetcher @Inject constructor(private val okHttpClient: OkH
               Log.w(TAG, "HTTP request failed with code: ${response.code}")
               Result.failure(Exception("HTTP ${response.code}"))
             }
-            contentType == null ||
-                contentType.type != "text" ||
-                contentType.subtype != "html" -> {
+            contentType == null || contentType.type != "text" || contentType.subtype != "html" -> {
               Log.w(TAG, "Skipping non-HTML response: url=$url contentType=$contentType")
               Result.failure(Exception("Unsupported Content-Type: $contentType"))
             }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/metadata/UrlMetadataFetcher.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/metadata/UrlMetadataFetcher.kt
@@ -49,16 +49,26 @@ class OkHttpUrlMetadataFetcher @Inject constructor(private val okHttpClient: OkH
             Request.Builder().url(url).header("User-Agent", "Pinosu/1.0 (Android)").build()
 
         okHttpClient.newCall(request).execute().use { response ->
-          if (!response.isSuccessful) {
-            Log.w(TAG, "HTTP request failed with code: ${response.code}")
-            Result.failure(Exception("HTTP ${response.code}"))
-          } else {
-            val html = response.body.string()
-            val metadata = parseMetadata(html, url)
+          val contentType = response.body.contentType()
+          when {
+            !response.isSuccessful -> {
+              Log.w(TAG, "HTTP request failed with code: ${response.code}")
+              Result.failure(Exception("HTTP ${response.code}"))
+            }
+            contentType == null ||
+                contentType.type != "text" ||
+                contentType.subtype != "html" -> {
+              Log.w(TAG, "Skipping non-HTML response: url=$url contentType=$contentType")
+              Result.failure(Exception("Unsupported Content-Type: $contentType"))
+            }
+            else -> {
+              val html = response.body.string()
+              val metadata = parseMetadata(html, url)
 
-            cache.put(url, metadata)
+              cache.put(url, metadata)
 
-            Result.success(metadata)
+              Result.success(metadata)
+            }
           }
         }
       } catch (e: IOException) {

--- a/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/data/metadata/OkHttpUrlMetadataFetcherTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/data/metadata/OkHttpUrlMetadataFetcherTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import okhttp3.Call
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
@@ -43,7 +44,7 @@ class OkHttpUrlMetadataFetcherTest {
             .protocol(Protocol.HTTP_1_1)
             .code(code)
             .message("OK")
-            .body(body.toResponseBody())
+            .body(body.toResponseBody("text/html".toMediaTypeOrNull()))
             .build()
     every { okHttpClient.newCall(any()) } returns call
     every { call.execute() } returns response


### PR DESCRIPTION
## Summary

Bookmark previews no longer download non-HTML resources (such as podcast MP3s), preventing `OutOfMemoryError` when several large media URLs are bookmarked.

## Details

The URL metadata fetcher reads the response body in full via `response.body.string()` to extract Open Graph tags. It previously did so without inspecting `Content-Type`, so bookmarked URLs that resolved to large binary resources (audio, video, images) were loaded entirely into memory. With multiple ~100 MB podcast MP3s being fetched concurrently, the heap was exhausted and the process crashed on the OkHttp `TaskRunner` thread.

This change inspects `Content-Type` immediately after receiving the response and aborts before reading the body when it is not `text/html`. Open Graph metadata only exists in HTML documents, so non-HTML responses could never contribute meaningful metadata.

## Confirmation

- Bookmark a URL that points to an MP3 (for example, a podcast episode link) and confirm that the bookmark list no longer crashes the app.
- Confirm that bookmarks pointing to HTML pages still display title and image metadata as before.
- Check `logcat` for `Skipping non-HTML response` entries when non-HTML URLs are encountered.

## Limitation

- `application/xhtml+xml` responses are also rejected even though they may carry Open Graph tags. The predicate can be widened later if real-world bookmarks rely on XHTML.
- HTML pages of arbitrary size are still read in full. Adding a response-size cap as defense in depth is left for a future change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced URL metadata fetching to validate content types, ensuring proper identification before parsing and improved handling of unsupported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->