### PR TITLE
feat(comment): add long-press menu to copy content or raw JSON

### DIFF
--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCardTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCardTest.kt
@@ -25,7 +25,7 @@ class CommentCardTest {
             authorPubkey = "pk1",
             createdAt = 1_700_000_000L)
 
-    composeTestRule.setContent { CommentCard(comment = comment) }
+    composeTestRule.setContent { CommentCard(comment = comment, onCopyContent = {}) }
 
     composeTestRule.onNodeWithText("A regular comment").assertIsDisplayed()
   }
@@ -36,7 +36,7 @@ class CommentCardTest {
     val comment =
         Comment(id = "c2", content = "Some comment", authorPubkey = "pk1", createdAt = timestamp)
 
-    composeTestRule.setContent { CommentCard(comment = comment) }
+    composeTestRule.setContent { CommentCard(comment = comment, onCopyContent = {}) }
 
     val expected = formatTimestamp(timestamp)
     composeTestRule.onNodeWithText(expected).assertIsDisplayed()
@@ -51,7 +51,9 @@ class CommentCardTest {
             authorPubkey = "pk3",
             createdAt = 1_700_000_000L)
 
-    composeTestRule.setContent { CommentCard(comment = comment, profileImageUrl = null) }
+    composeTestRule.setContent {
+      CommentCard(comment = comment, onCopyContent = {}, profileImageUrl = null)
+    }
 
     composeTestRule
         .onNodeWithContentDescription(getTestString(R.string.cd_commenter_avatar))

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -69,7 +69,8 @@ constructor(
                 content = event.content,
                 authorPubkey = event.pubkey,
                 createdAt = event.createdAt,
-                kind = event.kind)
+                kind = event.kind,
+                event = event)
           }
 
       Result.success(comments)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/model/Comment.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/model/Comment.kt
@@ -1,5 +1,7 @@
 package io.github.omochice.pinosu.feature.comment.domain.model
 
+import io.github.omochice.pinosu.core.model.NostrEvent
+
 /**
  * Comment displayed on the bookmark detail screen
  *
@@ -11,6 +13,7 @@ package io.github.omochice.pinosu.feature.comment.domain.model
  * @property authorPubkey Hex-encoded public key of the comment author
  * @property createdAt Unix timestamp in seconds
  * @property kind Nostr event kind (e.g., 1 for text note, 1111 for NIP-22 comment)
+ * @property event Original Nostr event, or null for synthetic author comments
  */
 data class Comment(
     val id: String,
@@ -18,6 +21,7 @@ data class Comment(
     val authorPubkey: String,
     val createdAt: Long,
     val kind: Int = KIND_COMMENT,
+    val event: NostrEvent? = null,
 ) {
   companion object {
     const val KIND_TEXT_NOTE = 1

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/domain/usecase/GetCommentsForBookmarkUseCaseImpl.kt
@@ -70,7 +70,8 @@ constructor(
                 content = event.content,
                 authorPubkey = event.pubkey,
                 createdAt = event.createdAt,
-                kind = event.kind)
+                kind = event.kind,
+                event = event)
           }
         }
         .getOrElse {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
@@ -32,12 +32,15 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -48,6 +51,8 @@ import io.github.omochice.pinosu.core.timestamp.formatTimestamp
 import io.github.omochice.pinosu.feature.comment.domain.model.Comment
 import io.github.omochice.pinosu.feature.comment.presentation.viewmodel.BookmarkDetailUiState
 import io.github.omochice.pinosu.ui.component.ErrorDialog
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 /**
  * Bookmark detail screen showing bookmark info and comments
@@ -129,6 +134,9 @@ private fun BookmarkDetailContent(
     paddingValues: PaddingValues,
     onOpenUrlFailed: () -> Unit,
 ) {
+  val clipboardManager = LocalClipboardManager.current
+  val json = remember { Json { prettyPrint = true } }
+
   if (uiState.isLoading) {
     Box(
         modifier = Modifier.fillMaxSize().padding(paddingValues),
@@ -163,7 +171,16 @@ private fun BookmarkDetailContent(
               if (comment.kind == Comment.KIND_TEXT_NOTE) {
                 QuoteCard(comment = comment, profileImageUrl = profileUrl)
               } else {
-                CommentCard(comment = comment, profileImageUrl = profileUrl)
+                CommentCard(
+                    comment = comment,
+                    profileImageUrl = profileUrl,
+                    onCopyContent = { content ->
+                      clipboardManager.setText(AnnotatedString(content))
+                    },
+                    onCopyRawJson =
+                        comment.event?.let { event ->
+                          { clipboardManager.setText(AnnotatedString(json.encodeToString(event))) }
+                        })
               }
             }
           }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
@@ -33,16 +33,16 @@ import io.github.omochice.pinosu.feature.comment.domain.model.Comment
  * Long-press shows a context menu to copy the comment content or raw event JSON.
  *
  * @param comment The comment to display
- * @param profileImageUrl Profile image URL for the comment author, or null for fallback icon
  * @param onCopyContent Called when the user selects "Copy content"
+ * @param profileImageUrl Profile image URL for the comment author, or null for fallback icon
  * @param onCopyRawJson Called when the user selects "Copy raw JSON", or null to hide the option
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun CommentCard(
     comment: Comment,
+    onCopyContent: (String) -> Unit,
     profileImageUrl: String? = null,
-    onCopyContent: (String) -> Unit = {},
     onCopyRawJson: (() -> Unit)? = null,
 ) {
   var showMenu by remember { mutableStateOf(false) }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
@@ -1,7 +1,6 @@
 package io.github.omochice.pinosu.feature.comment.presentation.ui
 
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -22,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.github.omochice.pinosu.R
@@ -37,7 +37,6 @@ import io.github.omochice.pinosu.feature.comment.domain.model.Comment
  * @param profileImageUrl Profile image URL for the comment author, or null for fallback icon
  * @param onCopyRawJson Called when the user selects "Copy raw JSON", or null to hide the option
  */
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun CommentCard(
     comment: Comment,
@@ -50,8 +49,9 @@ internal fun CommentCard(
   Box {
     Card(
         modifier =
-            Modifier.fillMaxWidth()
-                .combinedClickable(onClick = {}, onLongClick = { showMenu = true }),
+            Modifier.fillMaxWidth().pointerInput(Unit) {
+              detectTapGestures(onLongPress = { showMenu = true })
+            },
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
           Column(modifier = Modifier.padding(12.dp)) {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
@@ -1,5 +1,8 @@
 package io.github.omochice.pinosu.feature.comment.presentation.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,8 +11,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -20,25 +30,58 @@ import io.github.omochice.pinosu.feature.comment.domain.model.Comment
 /**
  * Card for displaying a NIP-22 kind 1111 comment
  *
+ * Long-press shows a context menu to copy the comment content or raw event JSON.
+ *
  * @param comment The comment to display
  * @param profileImageUrl Profile image URL for the comment author, or null for fallback icon
+ * @param onCopyContent Called when the user selects "Copy content"
+ * @param onCopyRawJson Called when the user selects "Copy raw JSON", or null to hide the option
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-internal fun CommentCard(comment: Comment, profileImageUrl: String? = null) {
-  Card(
-      modifier = Modifier.fillMaxWidth(),
-      elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
-      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
-        Column(modifier = Modifier.padding(12.dp)) {
-          Row(verticalAlignment = Alignment.CenterVertically) {
-            ProfileAvatar(
-                imageUrl = profileImageUrl,
-                contentDescription = stringResource(R.string.cd_commenter_avatar),
-                size = 24.dp,
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Column(modifier = Modifier.weight(1f)) { CommentBody(comment = comment) }
+internal fun CommentCard(
+    comment: Comment,
+    profileImageUrl: String? = null,
+    onCopyContent: (String) -> Unit = {},
+    onCopyRawJson: (() -> Unit)? = null,
+) {
+  var showMenu by remember { mutableStateOf(false) }
+
+  Box {
+    Card(
+        modifier =
+            Modifier.fillMaxWidth()
+                .combinedClickable(onClick = {}, onLongClick = { showMenu = true }),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+          Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+              ProfileAvatar(
+                  imageUrl = profileImageUrl,
+                  contentDescription = stringResource(R.string.cd_commenter_avatar),
+                  size = 24.dp,
+              )
+              Spacer(modifier = Modifier.width(8.dp))
+              Column(modifier = Modifier.weight(1f)) { CommentBody(comment = comment) }
+            }
           }
         }
+
+    DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+      DropdownMenuItem(
+          text = { Text(stringResource(R.string.menu_copy_content)) },
+          onClick = {
+            onCopyContent(comment.content)
+            showMenu = false
+          })
+      if (onCopyRawJson != null) {
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.menu_copy_raw_json)) },
+            onClick = {
+              onCopyRawJson()
+              showMenu = false
+            })
       }
+    }
+  }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -96,4 +96,7 @@
 
     <string name="settings_client_tag">クライアントタグ（NIP-89）</string>
     <string name="settings_client_tag_description">公開するイベントにPinosuのクライアント識別子を含める</string>
+
+    <string name="menu_copy_content">内容をコピー</string>
+    <string name="menu_copy_raw_json">Raw JSONをコピー</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,4 +101,7 @@
     <string name="settings_client_tag">Client Tag (NIP-89)</string>
     <string name="settings_client_tag_description">Include Pinosu client identifier in published events</string>
 
+    <string name="menu_copy_content">Copy content</string>
+    <string name="menu_copy_raw_json">Copy raw JSON</string>
+
 </resources>


### PR DESCRIPTION
## Summary

Add a long-press context menu to comment cards on the bookmark detail screen, with options to copy the comment content or the raw Nostr event JSON.

## Details

Until now there was no way to share or inspect the underlying payload of a comment. Long-pressing a comment card now opens a dropdown exposing two actions: "Copy content" copies the comment's text body, and "Copy raw JSON" copies the original Nostr event serialized as pretty-printed JSON. The raw JSON option is hidden when the original event is unavailable (for example, synthetic author comments), so the menu only offers actions that can succeed.

To make this possible, the `Comment` domain model now carries an optional `event: NostrEvent?` reference populated from `RelayCommentRepository` and `GetCommentsForBookmarkUseCaseImpl`. Keeping the original event on the model lets the presentation layer serialize it directly without an extra repository lookup, while the field remains nullable so callers that synthesize comments (without a backing event) continue to work unchanged.

## Confirmation

- Open the bookmark detail screen and verify the comment list is rendered.
- Long-press a NIP-22 (kind 1111) comment card and confirm the dropdown menu appears.
- Tap "Copy content" and verify the clipboard contains the comment text.
- Tap "Copy raw JSON" and verify the clipboard contains pretty-printed Nostr event JSON.
- For synthetic author comments (no underlying event), confirm only "Copy content" is shown.
- Switch the device locale to Japanese and verify the menu items are localized.

## Limitation

- The long-press menu is only attached to `CommentCard` (kind 1111). Quote cards (`KIND_TEXT_NOTE`) still have no context menu.