### PR TITLE
feat: add Copy nostr link action to bookmarks and comments

### DIFF
--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
@@ -79,4 +79,19 @@ class BookmarkItemCardTest {
         .onNodeWithText(getTestString(R.string.menu_copy_nostr_link))
         .assertDoesNotExist()
   }
+
+  @Test
+  fun copyRawJsonItemIsHiddenWhenLongPressCallbackIsNull() {
+    composeTestRule.setContent {
+      BookmarkItemCard(
+          bookmark = bookmark(rawJson = null),
+          onClick = {},
+          onLongPress = null,
+          onCopyNostrLink = { /* keep menu populated */ })
+    }
+
+    composeTestRule.onNodeWithText("Test Bookmark").performTouchInput { longClick() }
+
+    composeTestRule.onNodeWithText(getTestString(R.string.menu_copy_raw_json)).assertDoesNotExist()
+  }
 }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
@@ -1,0 +1,50 @@
+package io.github.omochice.pinosu.feature.bookmark.presentation.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import io.github.omochice.pinosu.R
+import io.github.omochice.pinosu.core.nip.nipb0.NipB0
+import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
+import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkedEvent
+import io.github.omochice.pinosu.getTestString
+import org.junit.Rule
+import org.junit.Test
+
+/** Compose UI tests for [BookmarkItemCard] */
+class BookmarkItemCardTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private fun bookmark(
+      rawJson: String? = "{\"id\":\"abc\",\"kind\":39701}",
+      dTag: String? = "abc"
+  ) =
+      BookmarkItem(
+          type = "event",
+          eventId = "abc",
+          title = "Test Bookmark",
+          url = "https://example.com",
+          urls = listOf("https://example.com"),
+          rawJson = rawJson,
+          event =
+              BookmarkedEvent(
+                  kind = NipB0.KIND_BOOKMARK_LIST,
+                  content = "hello",
+                  author = "def",
+                  createdAt = 1000L,
+                  tags = dTag?.let { listOf(listOf(NipB0.Tag.IDENTIFIER, it)) } ?: emptyList()))
+
+  @Test
+  fun longPressOpensDropdownMenuWithCopyRawJsonItem() {
+    composeTestRule.setContent {
+      BookmarkItemCard(bookmark = bookmark(), onClick = {}, onLongPress = {})
+    }
+
+    composeTestRule.onNodeWithText("Test Bookmark").performTouchInput { longClick() }
+
+    composeTestRule.onNodeWithText(getTestString(R.string.menu_copy_raw_json)).assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
@@ -4,12 +4,14 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkedEvent
 import io.github.omochice.pinosu.getTestString
+import org.junit.Assert.assertSame
 import org.junit.Rule
 import org.junit.Test
 
@@ -46,5 +48,21 @@ class BookmarkItemCardTest {
     composeTestRule.onNodeWithText("Test Bookmark").performTouchInput { longClick() }
 
     composeTestRule.onNodeWithText(getTestString(R.string.menu_copy_raw_json)).assertIsDisplayed()
+  }
+
+  @Test
+  fun selectingCopyNostrLinkInvokesCallbackWithBookmark() {
+    val target = bookmark()
+    var captured: BookmarkItem? = null
+
+    composeTestRule.setContent {
+      BookmarkItemCard(
+          bookmark = target, onClick = {}, onLongPress = {}, onCopyNostrLink = { captured = it })
+    }
+
+    composeTestRule.onNodeWithText("Test Bookmark").performTouchInput { longClick() }
+    composeTestRule.onNodeWithText(getTestString(R.string.menu_copy_nostr_link)).performClick()
+
+    assertSame("onCopyNostrLink should receive the same bookmark instance", target, captured)
   }
 }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
@@ -65,4 +65,18 @@ class BookmarkItemCardTest {
 
     assertSame("onCopyNostrLink should receive the same bookmark instance", target, captured)
   }
+
+  @Test
+  fun copyNostrLinkItemIsHiddenWhenCallbackIsNull() {
+    composeTestRule.setContent {
+      BookmarkItemCard(
+          bookmark = bookmark(), onClick = {}, onLongPress = {}, onCopyNostrLink = null)
+    }
+
+    composeTestRule.onNodeWithText("Test Bookmark").performTouchInput { longClick() }
+
+    composeTestRule
+        .onNodeWithText(getTestString(R.string.menu_copy_nostr_link))
+        .assertDoesNotExist()
+  }
 }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
@@ -3,21 +3,25 @@ package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
+import io.github.omochice.pinosu.R
+import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkedEvent
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState
+import io.github.omochice.pinosu.getTestString
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
-/** Compose UI tests for long-press on bookmark card */
+/** Compose UI tests for the long-press menu integration on [BookmarkScreen] */
 class BookmarkScreenLongPressTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test
-  fun longPressOnBookmarkCardTriggersCallbackWithRawJson() {
+  fun selectingCopyRawJsonFromMenuInvokesCallbackWithRawJson() {
     val expectedRawJson =
         """{"id":"abc","pubkey":"def","created_at":1000,"kind":39701,"tags":[],"content":"hello","sig":"xyz"}"""
     var capturedRawJson: String? = null
@@ -33,11 +37,11 @@ class BookmarkScreenLongPressTest {
                 rawJson = expectedRawJson,
                 event =
                     BookmarkedEvent(
-                        kind = 39701,
+                        kind = NipB0.KIND_BOOKMARK_LIST,
                         content = "hello",
                         author = "def",
                         createdAt = 1000,
-                        tags = emptyList())))
+                        tags = listOf(listOf(NipB0.Tag.IDENTIFIER, "abc")))))
 
     composeTestRule.setContent {
       BookmarkScreen(
@@ -49,7 +53,11 @@ class BookmarkScreenLongPressTest {
     }
 
     composeTestRule.onNodeWithText("Test Bookmark").performTouchInput { longClick() }
+    composeTestRule.onNodeWithText(getTestString(R.string.menu_copy_raw_json)).performClick()
 
-    assertEquals("Callback should receive rawJson", expectedRawJson, capturedRawJson)
+    assertEquals(
+        "Tapping Copy raw JSON should pass rawJson to the callback",
+        expectedRawJson,
+        capturedRawJson)
   }
 }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
@@ -90,4 +90,27 @@ class BookmarkScreenLongPressTest {
         "Encoded value should be a nostr:naddr1 URI but was '$capturedNostrLink'",
         capturedNostrLink!!.startsWith("nostr:naddr1"))
   }
+
+  @Test
+  fun copyNostrLinkIsHiddenWhenBookmarkHasNoDTag() {
+    val bookmarkWithoutDTag =
+        sampleBookmark.copy(event = sampleBookmark.event!!.copy(tags = emptyList()))
+
+    composeTestRule.setContent {
+      BookmarkScreen(
+          uiState =
+              BookmarkUiState(
+                  isLoading = false,
+                  allBookmarks = listOf(bookmarkWithoutDTag),
+                  userHexPubkey =
+                      "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"),
+          onRefresh = {},
+          onLoad = {})
+    }
+
+    composeTestRule.onNodeWithText("Test Bookmark").performTouchInput { longClick() }
+    composeTestRule
+        .onNodeWithText(getTestString(R.string.menu_copy_nostr_link))
+        .assertDoesNotExist()
+  }
 }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
@@ -30,12 +30,12 @@ class BookmarkScreenLongPressTest {
           url = "https://example.com",
           urls = listOf("https://example.com"),
           rawJson =
-              """{"id":"abc","pubkey":"def","created_at":1000,"kind":39701,"tags":[],"content":"hello","sig":"xyz"}""",
+              """{"id":"abc","pubkey":"64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924","created_at":1000,"kind":39701,"tags":[],"content":"hello","sig":"xyz"}""",
           event =
               BookmarkedEvent(
                   kind = NipB0.KIND_BOOKMARK_LIST,
                   content = "hello",
-                  author = "def",
+                  author = "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924",
                   createdAt = 1000,
                   tags = listOf(listOf(NipB0.Tag.IDENTIFIER, "abc"))))
 
@@ -47,7 +47,10 @@ class BookmarkScreenLongPressTest {
       BookmarkScreen(
           uiState =
               BookmarkUiState(
-                  isLoading = false, allBookmarks = listOf(sampleBookmark), userHexPubkey = "def"),
+                  isLoading = false,
+                  allBookmarks = listOf(sampleBookmark),
+                  userHexPubkey =
+                      "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"),
           onRefresh = {},
           onLoad = {},
           onLongPressBookmark = { rawJson -> capturedRawJson = rawJson })
@@ -70,7 +73,10 @@ class BookmarkScreenLongPressTest {
       BookmarkScreen(
           uiState =
               BookmarkUiState(
-                  isLoading = false, allBookmarks = listOf(sampleBookmark), userHexPubkey = "def"),
+                  isLoading = false,
+                  allBookmarks = listOf(sampleBookmark),
+                  userHexPubkey =
+                      "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"),
           onRefresh = {},
           onLoad = {},
           onCopyNostrLink = { encoded -> capturedNostrLink = encoded })

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
@@ -12,6 +12,8 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkedEvent
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState
 import io.github.omochice.pinosu.getTestString
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -20,33 +22,32 @@ class BookmarkScreenLongPressTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  private val sampleBookmark =
+      BookmarkItem(
+          type = "event",
+          eventId = "abc",
+          title = "Test Bookmark",
+          url = "https://example.com",
+          urls = listOf("https://example.com"),
+          rawJson =
+              """{"id":"abc","pubkey":"def","created_at":1000,"kind":39701,"tags":[],"content":"hello","sig":"xyz"}""",
+          event =
+              BookmarkedEvent(
+                  kind = NipB0.KIND_BOOKMARK_LIST,
+                  content = "hello",
+                  author = "def",
+                  createdAt = 1000,
+                  tags = listOf(listOf(NipB0.Tag.IDENTIFIER, "abc"))))
+
   @Test
   fun selectingCopyRawJsonFromMenuInvokesCallbackWithRawJson() {
-    val expectedRawJson =
-        """{"id":"abc","pubkey":"def","created_at":1000,"kind":39701,"tags":[],"content":"hello","sig":"xyz"}"""
     var capturedRawJson: String? = null
-
-    val bookmarks =
-        listOf(
-            BookmarkItem(
-                type = "event",
-                eventId = "abc",
-                title = "Test Bookmark",
-                url = "https://example.com",
-                urls = listOf("https://example.com"),
-                rawJson = expectedRawJson,
-                event =
-                    BookmarkedEvent(
-                        kind = NipB0.KIND_BOOKMARK_LIST,
-                        content = "hello",
-                        author = "def",
-                        createdAt = 1000,
-                        tags = listOf(listOf(NipB0.Tag.IDENTIFIER, "abc")))))
 
     composeTestRule.setContent {
       BookmarkScreen(
           uiState =
-              BookmarkUiState(isLoading = false, allBookmarks = bookmarks, userHexPubkey = "def"),
+              BookmarkUiState(
+                  isLoading = false, allBookmarks = listOf(sampleBookmark), userHexPubkey = "def"),
           onRefresh = {},
           onLoad = {},
           onLongPressBookmark = { rawJson -> capturedRawJson = rawJson })
@@ -57,7 +58,30 @@ class BookmarkScreenLongPressTest {
 
     assertEquals(
         "Tapping Copy raw JSON should pass rawJson to the callback",
-        expectedRawJson,
+        sampleBookmark.rawJson,
         capturedRawJson)
+  }
+
+  @Test
+  fun selectingCopyNostrLinkFromMenuInvokesCallbackWithNAddr() {
+    var capturedNostrLink: String? = null
+
+    composeTestRule.setContent {
+      BookmarkScreen(
+          uiState =
+              BookmarkUiState(
+                  isLoading = false, allBookmarks = listOf(sampleBookmark), userHexPubkey = "def"),
+          onRefresh = {},
+          onLoad = {},
+          onCopyNostrLink = { encoded -> capturedNostrLink = encoded })
+    }
+
+    composeTestRule.onNodeWithText("Test Bookmark").performTouchInput { longClick() }
+    composeTestRule.onNodeWithText(getTestString(R.string.menu_copy_nostr_link)).performClick()
+
+    assertNotNull("Tapping Copy nostr link should invoke the callback", capturedNostrLink)
+    assertTrue(
+        "Encoded value should be a nostr:naddr1 URI but was '$capturedNostrLink'",
+        capturedNostrLink!!.startsWith("nostr:naddr1"))
   }
 }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreenTest.kt
@@ -5,14 +5,19 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import io.github.omochice.pinosu.R
+import io.github.omochice.pinosu.core.model.NostrEvent
 import io.github.omochice.pinosu.feature.comment.domain.model.Comment
 import io.github.omochice.pinosu.feature.comment.presentation.viewmodel.BookmarkDetailUiState
 import io.github.omochice.pinosu.getTestString
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -178,6 +183,85 @@ class BookmarkDetailScreenTest {
 
     composeTestRule
         .onNodeWithContentDescription(getTestString(R.string.cd_post_comment))
+        .assertDoesNotExist()
+  }
+
+  @Test
+  fun selectingCopyNostrLinkOnKind1111CommentInvokesCallbackWithNEvent() {
+    var capturedNostrLink: String? = null
+    val pubkey = "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"
+    val eventId = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    val comment =
+        Comment(
+            id = eventId,
+            content = "Shareable comment",
+            authorPubkey = pubkey,
+            createdAt = 1_700_000_000L,
+            kind = Comment.KIND_COMMENT,
+            event =
+                NostrEvent(
+                    id = eventId,
+                    pubkey = pubkey,
+                    createdAt = 1_700_000_000L,
+                    kind = Comment.KIND_COMMENT,
+                    tags = emptyList(),
+                    content = "Shareable comment",
+                    sig = "sig"))
+
+    composeTestRule.setContent {
+      BookmarkDetailScreen(
+          uiState = BookmarkDetailUiState(comments = listOf(comment)),
+          bookmarkInfo =
+              BookmarkInfo(
+                  title = "Test",
+                  urls = listOf("https://example.com"),
+                  createdAt = 1_700_000_000L,
+                  authorPubkey = "pk_author"),
+          onCommentInputChange = {},
+          onPostComment = {},
+          onNavigateBack = {},
+          onDismissError = {},
+          onCopyNostrLink = { encoded -> capturedNostrLink = encoded })
+    }
+
+    composeTestRule.onNodeWithText("Shareable comment").performTouchInput { longClick() }
+    composeTestRule.onNodeWithText(getTestString(R.string.menu_copy_nostr_link)).performClick()
+
+    assertNotNull("Tapping Copy nostr link should invoke the callback", capturedNostrLink)
+    assertTrue(
+        "Encoded value should be a nostr:nevent1 URI but was '$capturedNostrLink'",
+        capturedNostrLink!!.startsWith("nostr:nevent1"))
+  }
+
+  @Test
+  fun copyNostrLinkIsHiddenForSyntheticAuthorCommentWithoutEvent() {
+    val syntheticAuthorComment =
+        Comment(
+            id = "author",
+            content = "Synthetic author comment",
+            authorPubkey = "pk1",
+            createdAt = 1_700_000_000L,
+            kind = Comment.KIND_COMMENT,
+            event = null)
+
+    composeTestRule.setContent {
+      BookmarkDetailScreen(
+          uiState = BookmarkDetailUiState(comments = listOf(syntheticAuthorComment)),
+          bookmarkInfo =
+              BookmarkInfo(
+                  title = "Test",
+                  urls = listOf("https://example.com"),
+                  createdAt = 1_700_000_000L,
+                  authorPubkey = "pk_author"),
+          onCommentInputChange = {},
+          onPostComment = {},
+          onNavigateBack = {},
+          onDismissError = {})
+    }
+
+    composeTestRule.onNodeWithText("Synthetic author comment").performTouchInput { longClick() }
+    composeTestRule
+        .onNodeWithText(getTestString(R.string.menu_copy_nostr_link))
         .assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCardTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCardTest.kt
@@ -2,12 +2,17 @@ package io.github.omochice.pinosu.feature.comment.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
 import io.github.omochice.pinosu.R
+import io.github.omochice.pinosu.core.model.NostrEvent
 import io.github.omochice.pinosu.core.timestamp.formatTimestamp
 import io.github.omochice.pinosu.feature.comment.domain.model.Comment
 import io.github.omochice.pinosu.getTestString
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -58,5 +63,34 @@ class CommentCardTest {
     composeTestRule
         .onNodeWithContentDescription(getTestString(R.string.cd_commenter_avatar))
         .assertIsDisplayed()
+  }
+
+  @Test
+  fun selectingCopyNostrLinkInvokesCallback() {
+    var invoked = false
+    val comment =
+        Comment(
+            id = "c-nostr",
+            content = "A comment to share",
+            authorPubkey = "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924",
+            createdAt = 1_700_000_000L,
+            event =
+                NostrEvent(
+                    id = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+                    pubkey = "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924",
+                    createdAt = 1_700_000_000L,
+                    kind = Comment.KIND_COMMENT,
+                    tags = emptyList(),
+                    content = "A comment to share",
+                    sig = "sig"))
+
+    composeTestRule.setContent {
+      CommentCard(comment = comment, onCopyContent = {}, onCopyNostrLink = { invoked = true })
+    }
+
+    composeTestRule.onNodeWithText("A comment to share").performTouchInput { longClick() }
+    composeTestRule.onNodeWithText(getTestString(R.string.menu_copy_nostr_link)).performClick()
+
+    assertTrue("onCopyNostrLink should be invoked", invoked)
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoder.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoder.kt
@@ -7,7 +7,9 @@ import javax.inject.Inject
 /**
  * Encodes Nostr events into NIP-19 `nostr:` URIs.
  *
- * @see Nip19EventResolver for the inverse operation.
+ * Currently produces `nevent` and `naddr` references. The reverse operation is partially handled by
+ * [Nip19EventResolver], which extracts hex event IDs from `nostr:nevent1...` references embedded in
+ * text content; it does not decode `naddr` or expose the full TLV payload.
  */
 class Nip19EventEncoder @Inject constructor() {
 

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoder.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoder.kt
@@ -1,0 +1,25 @@
+package io.github.omochice.pinosu.core.nip.nip19
+
+import com.vitorpamplona.quartz.nip19Bech32.entities.NAddress
+import javax.inject.Inject
+
+/**
+ * Encodes Nostr events into NIP-19 `nostr:` URIs.
+ *
+ * @see Nip19EventResolver for the inverse operation.
+ */
+class Nip19EventEncoder @Inject constructor() {
+
+  /**
+   * Encode a parameterized replaceable event reference as a `nostr:naddr1...` URI.
+   *
+   * @param kind Nostr event kind (e.g. 39701 for NIP-B0 bookmarks).
+   * @param pubkey Hex-encoded author public key.
+   * @param dTag `d` tag identifier of the addressable event.
+   * @return URI of the form `nostr:naddr1...`.
+   */
+  fun encodeNAddr(kind: Int, pubkey: String, dTag: String): String {
+    val bech32 = NAddress.create(kind = kind, pubKeyHex = pubkey, dTag = dTag, relay = null)
+    return "nostr:$bech32"
+  }
+}

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoder.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoder.kt
@@ -1,6 +1,7 @@
 package io.github.omochice.pinosu.core.nip.nip19
 
 import com.vitorpamplona.quartz.nip19Bech32.entities.NAddress
+import com.vitorpamplona.quartz.nip19Bech32.entities.NEvent
 import javax.inject.Inject
 
 /**
@@ -20,6 +21,19 @@ class Nip19EventEncoder @Inject constructor() {
    */
   fun encodeNAddr(kind: Int, pubkey: String, dTag: String): String {
     val bech32 = NAddress.create(kind = kind, pubKeyHex = pubkey, dTag = dTag, relay = null)
+    return "nostr:$bech32"
+  }
+
+  /**
+   * Encode a regular event reference as a `nostr:nevent1...` URI.
+   *
+   * @param eventId Hex-encoded event ID.
+   * @param pubkey Hex-encoded author public key.
+   * @param kind Nostr event kind (e.g. 1111 for NIP-22 comments).
+   * @return URI of the form `nostr:nevent1...`.
+   */
+  fun encodeNEvent(eventId: String, pubkey: String, kind: Int): String {
+    val bech32 = NEvent.create(idHex = eventId, author = pubkey, kind = kind, relay = null)
     return "nostr:$bech32"
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/model/Bookmark.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/model/Bookmark.kt
@@ -1,5 +1,7 @@
 package io.github.omochice.pinosu.feature.bookmark.domain.model
 
+import io.github.omochice.pinosu.core.nip.nipb0.NipB0
+
 /**
  * Bookmark item from kind:39701
  *
@@ -43,6 +45,15 @@ data class BookmarkedEvent(
     val createdAt: Long,
     val tags: List<List<String>> = emptyList(),
 )
+
+/**
+ * Returns the value of the NIP-B0 `d` tag identifier, or null if absent.
+ *
+ * The `d` tag is required to compute the addressable event coordinate used in `nostr:naddr1...`
+ * references for NIP-B0 (kind 39701) bookmarks.
+ */
+fun BookmarkedEvent.dTag(): String? =
+    tags.firstOrNull { it.size >= 2 && it[0] == NipB0.Tag.IDENTIFIER }?.get(1)
 
 /**
  * Bookmark list (kind:39701)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -23,17 +24,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.core.timestamp.formatTimestamp
@@ -99,9 +98,7 @@ private fun BookmarkCardShell(
   val hasMenuItems = onLongPress != null || onCopyNostrLink != null
   var showMenu by remember { mutableStateOf(false) }
   var pressOffset by remember { mutableStateOf(Offset.Zero) }
-  var anchorHeightPx by remember { mutableIntStateOf(0) }
   val interactionSource = remember { MutableInteractionSource() }
-  val density = LocalDensity.current
 
   LaunchedEffect(interactionSource) {
     interactionSource.interactions.collect { interaction ->
@@ -128,7 +125,7 @@ private fun BookmarkCardShell(
         Modifier
       }
 
-  Box(modifier = Modifier.onGloballyPositioned { anchorHeightPx = it.size.height }) {
+  Box {
     Card(
         modifier = Modifier.fillMaxWidth().then(clickModifier),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -143,15 +140,14 @@ private fun BookmarkCardShell(
           content()
         }
 
-    BookmarkLongPressMenu(
-        expanded = showMenu,
-        offset =
-            with(density) {
-              DpOffset(pressOffset.x.toDp(), (pressOffset.y - anchorHeightPx).toDp())
-            },
-        onDismiss = { showMenu = false },
-        onCopyRawJson = onLongPress?.let { handler -> { handler(bookmark) } },
-        onCopyNostrLink = onCopyNostrLink?.let { handler -> { handler(bookmark) } })
+    Box(modifier = Modifier.offset { IntOffset(pressOffset.x.toInt(), pressOffset.y.toInt()) }) {
+      BookmarkLongPressMenu(
+          expanded = showMenu,
+          offset = DpOffset.Zero,
+          onDismiss = { showMenu = false },
+          onCopyRawJson = onLongPress?.let { handler -> { handler(bookmark) } },
+          onCopyNostrLink = onCopyNostrLink?.let { handler -> { handler(bookmark) } })
+    }
   }
 }
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
@@ -2,6 +2,7 @@ package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,12 +13,20 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.core.timestamp.formatTimestamp
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 
@@ -67,28 +76,40 @@ private fun BookmarkCardShell(
     content: @Composable () -> Unit,
 ) {
   val hasUrls = bookmark.urls.isNotEmpty()
+  var showMenu by remember { mutableStateOf(false) }
 
   val clickModifier =
       if (hasUrls) {
         Modifier.combinedClickable(
-            onClick = { onClick(bookmark) }, onLongClick = { onLongPress(bookmark) })
+            onClick = { onClick(bookmark) }, onLongClick = { showMenu = true })
       } else {
         Modifier
       }
 
-  Card(
-      modifier = Modifier.fillMaxWidth().then(clickModifier),
-      elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-      colors =
-          CardDefaults.cardColors(
-              containerColor =
-                  if (hasUrls) {
-                    MaterialTheme.colorScheme.surface
-                  } else {
-                    MaterialTheme.colorScheme.surfaceVariant
-                  })) {
-        content()
-      }
+  Box {
+    Card(
+        modifier = Modifier.fillMaxWidth().then(clickModifier),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor =
+                    if (hasUrls) {
+                      MaterialTheme.colorScheme.surface
+                    } else {
+                      MaterialTheme.colorScheme.surfaceVariant
+                    })) {
+          content()
+        }
+
+    DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+      DropdownMenuItem(
+          text = { Text(stringResource(R.string.menu_copy_raw_json)) },
+          onClick = {
+            onLongPress(bookmark)
+            showMenu = false
+          })
+    }
+  }
 }
 
 @Composable

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
@@ -35,7 +35,7 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 fun BookmarkItemCard(
     bookmark: BookmarkItem,
     onClick: (BookmarkItem) -> Unit,
-    onLongPress: (BookmarkItem) -> Unit,
+    onLongPress: ((BookmarkItem) -> Unit)?,
     onCopyNostrLink: ((BookmarkItem) -> Unit)? = null,
 ) {
   BookmarkCardShell(
@@ -59,7 +59,7 @@ fun BookmarkItemCard(
 fun BookmarkGridItemCard(
     bookmark: BookmarkItem,
     onClick: (BookmarkItem) -> Unit,
-    onLongPress: (BookmarkItem) -> Unit,
+    onLongPress: ((BookmarkItem) -> Unit)?,
     onCopyNostrLink: ((BookmarkItem) -> Unit)? = null,
 ) {
   BookmarkCardShell(
@@ -82,7 +82,7 @@ fun BookmarkGridItemCard(
 private fun BookmarkCardShell(
     bookmark: BookmarkItem,
     onClick: (BookmarkItem) -> Unit,
-    onLongPress: (BookmarkItem) -> Unit,
+    onLongPress: ((BookmarkItem) -> Unit)?,
     onCopyNostrLink: ((BookmarkItem) -> Unit)?,
     content: @Composable () -> Unit,
 ) {
@@ -113,12 +113,14 @@ private fun BookmarkCardShell(
         }
 
     DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
-      DropdownMenuItem(
-          text = { Text(stringResource(R.string.menu_copy_raw_json)) },
-          onClick = {
-            onLongPress(bookmark)
-            showMenu = false
-          })
+      onLongPress?.let { handler ->
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.menu_copy_raw_json)) },
+            onClick = {
+              handler(bookmark)
+              showMenu = false
+            })
+      }
       onCopyNostrLink?.let { handler ->
         DropdownMenuItem(
             text = { Text(stringResource(R.string.menu_copy_nostr_link)) },

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
@@ -23,11 +23,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -97,6 +99,7 @@ private fun BookmarkCardShell(
   val hasMenuItems = onLongPress != null || onCopyNostrLink != null
   var showMenu by remember { mutableStateOf(false) }
   var pressOffset by remember { mutableStateOf(Offset.Zero) }
+  var anchorHeightPx by remember { mutableIntStateOf(0) }
   val interactionSource = remember { MutableInteractionSource() }
   val density = LocalDensity.current
 
@@ -125,7 +128,7 @@ private fun BookmarkCardShell(
         Modifier
       }
 
-  Box {
+  Box(modifier = Modifier.onGloballyPositioned { anchorHeightPx = it.size.height }) {
     Card(
         modifier = Modifier.fillMaxWidth().then(clickModifier),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -142,7 +145,10 @@ private fun BookmarkCardShell(
 
     BookmarkLongPressMenu(
         expanded = showMenu,
-        offset = with(density) { DpOffset(pressOffset.x.toDp(), pressOffset.y.toDp()) },
+        offset =
+            with(density) {
+              DpOffset(pressOffset.x.toDp(), (pressOffset.y - anchorHeightPx).toDp())
+            },
         onDismiss = { showMenu = false },
         onCopyRawJson = onLongPress?.let { handler -> { handler(bookmark) } },
         onCopyNostrLink = onCopyNostrLink?.let { handler -> { handler(bookmark) } })

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
@@ -36,17 +36,22 @@ fun BookmarkItemCard(
     bookmark: BookmarkItem,
     onClick: (BookmarkItem) -> Unit,
     onLongPress: (BookmarkItem) -> Unit,
+    onCopyNostrLink: (BookmarkItem) -> Unit = {},
 ) {
-  BookmarkCardShell(bookmark = bookmark, onClick = onClick, onLongPress = onLongPress) {
-    Row(modifier = Modifier.padding(16.dp)) {
-      OgpThumbnail(
-          imageUrl = bookmark.imageUrl,
-          contentDescription = bookmark.title,
-          modifier = Modifier.size(80.dp))
-      Spacer(modifier = Modifier.width(12.dp))
-      BookmarkCardTextContent(bookmark = bookmark, modifier = Modifier.weight(1f))
-    }
-  }
+  BookmarkCardShell(
+      bookmark = bookmark,
+      onClick = onClick,
+      onLongPress = onLongPress,
+      onCopyNostrLink = onCopyNostrLink) {
+        Row(modifier = Modifier.padding(16.dp)) {
+          OgpThumbnail(
+              imageUrl = bookmark.imageUrl,
+              contentDescription = bookmark.title,
+              modifier = Modifier.size(80.dp))
+          Spacer(modifier = Modifier.width(12.dp))
+          BookmarkCardTextContent(bookmark = bookmark, modifier = Modifier.weight(1f))
+        }
+      }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -55,16 +60,21 @@ fun BookmarkGridItemCard(
     bookmark: BookmarkItem,
     onClick: (BookmarkItem) -> Unit,
     onLongPress: (BookmarkItem) -> Unit,
+    onCopyNostrLink: (BookmarkItem) -> Unit = {},
 ) {
-  BookmarkCardShell(bookmark = bookmark, onClick = onClick, onLongPress = onLongPress) {
-    Column {
-      OgpThumbnail(
-          imageUrl = bookmark.imageUrl,
-          contentDescription = bookmark.title,
-          modifier = Modifier.fillMaxWidth().height(100.dp))
-      BookmarkCardTextContent(bookmark = bookmark, modifier = Modifier.padding(12.dp))
-    }
-  }
+  BookmarkCardShell(
+      bookmark = bookmark,
+      onClick = onClick,
+      onLongPress = onLongPress,
+      onCopyNostrLink = onCopyNostrLink) {
+        Column {
+          OgpThumbnail(
+              imageUrl = bookmark.imageUrl,
+              contentDescription = bookmark.title,
+              modifier = Modifier.fillMaxWidth().height(100.dp))
+          BookmarkCardTextContent(bookmark = bookmark, modifier = Modifier.padding(12.dp))
+        }
+      }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -73,6 +83,7 @@ private fun BookmarkCardShell(
     bookmark: BookmarkItem,
     onClick: (BookmarkItem) -> Unit,
     onLongPress: (BookmarkItem) -> Unit,
+    onCopyNostrLink: (BookmarkItem) -> Unit,
     content: @Composable () -> Unit,
 ) {
   val hasUrls = bookmark.urls.isNotEmpty()
@@ -106,6 +117,12 @@ private fun BookmarkCardShell(
           text = { Text(stringResource(R.string.menu_copy_raw_json)) },
           onClick = {
             onLongPress(bookmark)
+            showMenu = false
+          })
+      DropdownMenuItem(
+          text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
+          onClick = {
+            onCopyNostrLink(bookmark)
             showMenu = false
           })
     }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
@@ -87,12 +87,19 @@ private fun BookmarkCardShell(
     content: @Composable () -> Unit,
 ) {
   val hasUrls = bookmark.urls.isNotEmpty()
+  val hasMenuItems = onLongPress != null || onCopyNostrLink != null
   var showMenu by remember { mutableStateOf(false) }
 
+  val onLongClickHandler: (() -> Unit)? =
+      if (hasMenuItems) {
+        { showMenu = true }
+      } else {
+        null
+      }
   val clickModifier =
       if (hasUrls) {
         Modifier.combinedClickable(
-            onClick = { onClick(bookmark) }, onLongClick = { showMenu = true })
+            onClick = { onClick(bookmark) }, onLongClick = onLongClickHandler)
       } else {
         Modifier
       }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
@@ -36,7 +36,7 @@ fun BookmarkItemCard(
     bookmark: BookmarkItem,
     onClick: (BookmarkItem) -> Unit,
     onLongPress: (BookmarkItem) -> Unit,
-    onCopyNostrLink: (BookmarkItem) -> Unit = {},
+    onCopyNostrLink: ((BookmarkItem) -> Unit)? = null,
 ) {
   BookmarkCardShell(
       bookmark = bookmark,
@@ -60,7 +60,7 @@ fun BookmarkGridItemCard(
     bookmark: BookmarkItem,
     onClick: (BookmarkItem) -> Unit,
     onLongPress: (BookmarkItem) -> Unit,
-    onCopyNostrLink: (BookmarkItem) -> Unit = {},
+    onCopyNostrLink: ((BookmarkItem) -> Unit)? = null,
 ) {
   BookmarkCardShell(
       bookmark = bookmark,
@@ -83,7 +83,7 @@ private fun BookmarkCardShell(
     bookmark: BookmarkItem,
     onClick: (BookmarkItem) -> Unit,
     onLongPress: (BookmarkItem) -> Unit,
-    onCopyNostrLink: (BookmarkItem) -> Unit,
+    onCopyNostrLink: ((BookmarkItem) -> Unit)?,
     content: @Composable () -> Unit,
 ) {
   val hasUrls = bookmark.urls.isNotEmpty()
@@ -119,12 +119,14 @@ private fun BookmarkCardShell(
             onLongPress(bookmark)
             showMenu = false
           })
-      DropdownMenuItem(
-          text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
-          onClick = {
-            onCopyNostrLink(bookmark)
-            showMenu = false
-          })
+      onCopyNostrLink?.let { handler ->
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
+            onClick = {
+              handler(bookmark)
+              showMenu = false
+            })
+      }
     }
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
@@ -1,7 +1,10 @@
 package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,13 +21,17 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.core.timestamp.formatTimestamp
@@ -89,6 +96,17 @@ private fun BookmarkCardShell(
   val hasUrls = bookmark.urls.isNotEmpty()
   val hasMenuItems = onLongPress != null || onCopyNostrLink != null
   var showMenu by remember { mutableStateOf(false) }
+  var pressOffset by remember { mutableStateOf(Offset.Zero) }
+  val interactionSource = remember { MutableInteractionSource() }
+  val density = LocalDensity.current
+
+  LaunchedEffect(interactionSource) {
+    interactionSource.interactions.collect { interaction ->
+      if (interaction is PressInteraction.Press) {
+        pressOffset = interaction.pressPosition
+      }
+    }
+  }
 
   val onLongClickHandler: (() -> Unit)? =
       if (hasMenuItems) {
@@ -99,7 +117,10 @@ private fun BookmarkCardShell(
   val clickModifier =
       if (hasUrls) {
         Modifier.combinedClickable(
-            onClick = { onClick(bookmark) }, onLongClick = onLongClickHandler)
+            interactionSource = interactionSource,
+            indication = LocalIndication.current,
+            onClick = { onClick(bookmark) },
+            onLongClick = onLongClickHandler)
       } else {
         Modifier
       }
@@ -119,23 +140,39 @@ private fun BookmarkCardShell(
           content()
         }
 
-    DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
-      onLongPress?.let { handler ->
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.menu_copy_raw_json)) },
-            onClick = {
-              handler(bookmark)
-              showMenu = false
-            })
-      }
-      onCopyNostrLink?.let { handler ->
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
-            onClick = {
-              handler(bookmark)
-              showMenu = false
-            })
-      }
+    BookmarkLongPressMenu(
+        expanded = showMenu,
+        offset = with(density) { DpOffset(pressOffset.x.toDp(), pressOffset.y.toDp()) },
+        onDismiss = { showMenu = false },
+        onCopyRawJson = onLongPress?.let { handler -> { handler(bookmark) } },
+        onCopyNostrLink = onCopyNostrLink?.let { handler -> { handler(bookmark) } })
+  }
+}
+
+@Composable
+private fun BookmarkLongPressMenu(
+    expanded: Boolean,
+    offset: DpOffset,
+    onDismiss: () -> Unit,
+    onCopyRawJson: (() -> Unit)?,
+    onCopyNostrLink: (() -> Unit)?,
+) {
+  DropdownMenu(expanded = expanded, onDismissRequest = onDismiss, offset = offset) {
+    onCopyRawJson?.let { handler ->
+      DropdownMenuItem(
+          text = { Text(stringResource(R.string.menu_copy_raw_json)) },
+          onClick = {
+            handler()
+            onDismiss()
+          })
+    }
+    onCopyNostrLink?.let { handler ->
+      DropdownMenuItem(
+          text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
+          onClick = {
+            handler()
+            onDismiss()
+          })
     }
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCard.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import io.github.omochice.pinosu.R
@@ -143,7 +142,6 @@ private fun BookmarkCardShell(
     Box(modifier = Modifier.offset { IntOffset(pressOffset.x.toInt(), pressOffset.y.toInt()) }) {
       BookmarkLongPressMenu(
           expanded = showMenu,
-          offset = DpOffset.Zero,
           onDismiss = { showMenu = false },
           onCopyRawJson = onLongPress?.let { handler -> { handler(bookmark) } },
           onCopyNostrLink = onCopyNostrLink?.let { handler -> { handler(bookmark) } })
@@ -154,12 +152,11 @@ private fun BookmarkCardShell(
 @Composable
 private fun BookmarkLongPressMenu(
     expanded: Boolean,
-    offset: DpOffset,
     onDismiss: () -> Unit,
     onCopyRawJson: (() -> Unit)?,
     onCopyNostrLink: (() -> Unit)?,
 ) {
-  DropdownMenu(expanded = expanded, onDismissRequest = onDismiss, offset = offset) {
+  DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
     onCopyRawJson?.let { handler ->
       DropdownMenuItem(
           text = { Text(stringResource(R.string.menu_copy_raw_json)) },

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkListCallbacks.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkListCallbacks.kt
@@ -7,12 +7,15 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
  *
  * @property onRefresh Callback when pull-to-refresh is triggered
  * @property onClick Callback when a bookmark card is tapped
- * @property onLongPress Callback when a bookmark card is long-pressed
+ * @property onLongPress Callback invoked when "Copy raw JSON" is selected from the long-press menu
+ * @property onCopyNostrLink Callback invoked when "Copy nostr link" is selected from the long-press
+ *   menu
  * @property onLoadMore Callback when user scrolls near the end of the list to load older bookmarks
  */
 data class BookmarkListCallbacks(
     val onRefresh: () -> Unit,
     val onClick: (BookmarkItem) -> Unit,
     val onLongPress: (BookmarkItem) -> Unit,
+    val onCopyNostrLink: (BookmarkItem) -> Unit,
     val onLoadMore: () -> Unit,
 )

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -47,10 +47,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.core.nip.nip19.Nip19EventEncoder
-import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkDisplayMode
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkedEvent
+import io.github.omochice.pinosu.feature.bookmark.domain.model.dTag
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkFilterMode
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -146,9 +146,6 @@ fun BookmarkScreen(
             modifier = Modifier.padding(paddingValues).fillMaxSize())
       }
 }
-
-private fun BookmarkedEvent.dTag(): String? =
-    tags.firstOrNull { it.size >= 2 && it[0] == NipB0.Tag.IDENTIFIER }?.get(1)
 
 @Composable
 private fun BookmarkPager(

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -104,13 +104,13 @@ fun BookmarkScreen(
   }
 
   val onBookmarkCopyNostrLink: (BookmarkItem) -> Unit = { bookmark ->
-    bookmark.event?.dTag()?.let { dTag ->
-      val encoded =
-          encoder.encodeNAddr(
-              kind = bookmark.event.kind, pubkey = bookmark.event.author, dTag = dTag)
-      clipboardManager.setClip(ClipEntry(ClipData.newPlainText("nostrLink", encoded)))
-      hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-      onCopyNostrLink(encoded)
+    bookmark.event?.let { event ->
+      event.dTag()?.let { dTag ->
+        val encoded = encoder.encodeNAddr(kind = event.kind, pubkey = event.author, dTag = dTag)
+        clipboardManager.setClip(ClipEntry(ClipData.newPlainText("nostrLink", encoded)))
+        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+        onCopyNostrLink(encoded)
+      }
     }
   }
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -304,7 +304,7 @@ private fun BookmarkListView(
           BookmarkItemCard(
               bookmark = bookmark,
               onClick = callbacks.onClick,
-              onLongPress = callbacks.onLongPress,
+              onLongPress = bookmark.rawJson?.let { callbacks.onLongPress },
               onCopyNostrLink = bookmark.event?.dTag()?.let { callbacks.onCopyNostrLink })
         }
         if (isLoadingMore) {
@@ -348,7 +348,7 @@ private fun BookmarkGridView(
           BookmarkGridItemCard(
               bookmark = bookmark,
               onClick = callbacks.onClick,
-              onLongPress = callbacks.onLongPress,
+              onLongPress = bookmark.rawJson?.let { callbacks.onLongPress },
               onCopyNostrLink = bookmark.event?.dTag()?.let { callbacks.onCopyNostrLink })
         }
         if (isLoadingMore) {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -305,7 +305,7 @@ private fun BookmarkListView(
               bookmark = bookmark,
               onClick = callbacks.onClick,
               onLongPress = callbacks.onLongPress,
-              onCopyNostrLink = callbacks.onCopyNostrLink)
+              onCopyNostrLink = bookmark.event?.dTag()?.let { callbacks.onCopyNostrLink })
         }
         if (isLoadingMore) {
           item {
@@ -349,7 +349,7 @@ private fun BookmarkGridView(
               bookmark = bookmark,
               onClick = callbacks.onClick,
               onLongPress = callbacks.onLongPress,
-              onCopyNostrLink = callbacks.onCopyNostrLink)
+              onCopyNostrLink = bookmark.event?.dTag()?.let { callbacks.onCopyNostrLink })
         }
         if (isLoadingMore) {
           item {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -55,6 +55,8 @@ import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.Bookmar
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState
 import kotlinx.coroutines.flow.distinctUntilChanged
 
+private val sharedEncoder = Nip19EventEncoder()
+
 /**
  * Composable function for bookmark list screen
  *
@@ -93,7 +95,6 @@ fun BookmarkScreen(
 
   val clipboardManager = LocalClipboardManager.current
   val hapticFeedback = LocalHapticFeedback.current
-  val encoder = remember { Nip19EventEncoder() }
 
   val onBookmarkLongPress: (BookmarkItem) -> Unit = { bookmark ->
     bookmark.rawJson?.let { rawJson ->
@@ -106,7 +107,8 @@ fun BookmarkScreen(
   val onBookmarkCopyNostrLink: (BookmarkItem) -> Unit = { bookmark ->
     bookmark.event?.let { event ->
       event.dTag()?.let { dTag ->
-        val encoded = encoder.encodeNAddr(kind = event.kind, pubkey = event.author, dTag = dTag)
+        val encoded =
+            sharedEncoder.encodeNAddr(kind = event.kind, pubkey = event.author, dTag = dTag)
         clipboardManager.setClip(ClipEntry(ClipData.newPlainText("nostrLink", encoded)))
         hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
         onCopyNostrLink(encoded)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.omochice.pinosu.R
+import io.github.omochice.pinosu.core.nip.nip19.Nip19EventEncoder
+import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkDisplayMode
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkedEvent
@@ -66,7 +68,9 @@ import kotlinx.coroutines.flow.distinctUntilChanged
  * @param onTabSelected Callback when a filter tab is selected
  * @param onAddBookmark Callback when FAB is clicked to add a bookmark
  * @param onBookmarkDetailNavigate Callback when a bookmark card is tapped to navigate to detail
- * @param onLongPressBookmark Callback when a bookmark card is long-pressed with rawJson
+ * @param onLongPressBookmark Callback notified with rawJson when "Copy raw JSON" is selected
+ * @param onCopyNostrLink Callback notified with the encoded nostr:naddr1 URI when "Copy nostr link"
+ *   is selected
  * @param onLoadMore Callback when user scrolls near the end of the list to load older bookmarks
  * @param isReadOnly Whether to hide write-only UI (FAB) for read-only login
  */
@@ -81,6 +85,7 @@ fun BookmarkScreen(
     onAddBookmark: () -> Unit = {},
     onBookmarkDetailNavigate: (BookmarkItem) -> Unit = {},
     onLongPressBookmark: (String) -> Unit = {},
+    onCopyNostrLink: (String) -> Unit = {},
     onLoadMore: () -> Unit = {},
     isReadOnly: Boolean = false,
 ) {
@@ -88,6 +93,7 @@ fun BookmarkScreen(
 
   val clipboardManager = LocalClipboardManager.current
   val hapticFeedback = LocalHapticFeedback.current
+  val encoder = remember { Nip19EventEncoder() }
 
   val onBookmarkLongPress: (BookmarkItem) -> Unit = { bookmark ->
     bookmark.rawJson?.let { rawJson ->
@@ -97,11 +103,23 @@ fun BookmarkScreen(
     }
   }
 
+  val onBookmarkCopyNostrLink: (BookmarkItem) -> Unit = { bookmark ->
+    bookmark.event?.dTag()?.let { dTag ->
+      val encoded =
+          encoder.encodeNAddr(
+              kind = bookmark.event.kind, pubkey = bookmark.event.author, dTag = dTag)
+      clipboardManager.setClip(ClipEntry(ClipData.newPlainText("nostrLink", encoded)))
+      hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+      onCopyNostrLink(encoded)
+    }
+  }
+
   val callbacks =
       BookmarkListCallbacks(
           onRefresh = onRefresh,
           onClick = onBookmarkDetailNavigate,
           onLongPress = onBookmarkLongPress,
+          onCopyNostrLink = onBookmarkCopyNostrLink,
           onLoadMore = onLoadMore,
       )
 
@@ -128,6 +146,9 @@ fun BookmarkScreen(
             modifier = Modifier.padding(paddingValues).fillMaxSize())
       }
 }
+
+private fun BookmarkedEvent.dTag(): String? =
+    tags.firstOrNull { it.size >= 2 && it[0] == NipB0.Tag.IDENTIFIER }?.get(1)
 
 @Composable
 private fun BookmarkPager(
@@ -281,7 +302,10 @@ private fun BookmarkListView(
       verticalArrangement = Arrangement.spacedBy(8.dp)) {
         items(bookmarks, key = { bookmark -> bookmark.stableKey }) { bookmark ->
           BookmarkItemCard(
-              bookmark = bookmark, onClick = callbacks.onClick, onLongPress = callbacks.onLongPress)
+              bookmark = bookmark,
+              onClick = callbacks.onClick,
+              onLongPress = callbacks.onLongPress,
+              onCopyNostrLink = callbacks.onCopyNostrLink)
         }
         if (isLoadingMore) {
           item {
@@ -322,7 +346,10 @@ private fun BookmarkGridView(
       horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         items(bookmarks, key = { bookmark -> bookmark.stableKey }) { bookmark ->
           BookmarkGridItemCard(
-              bookmark = bookmark, onClick = callbacks.onClick, onLongPress = callbacks.onLongPress)
+              bookmark = bookmark,
+              onClick = callbacks.onClick,
+              onLongPress = callbacks.onLongPress,
+              onCopyNostrLink = callbacks.onCopyNostrLink)
         }
         if (isLoadingMore) {
           item {

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import io.github.omochice.pinosu.R
+import io.github.omochice.pinosu.core.nip.nip19.Nip19EventEncoder
 import io.github.omochice.pinosu.core.timestamp.formatTimestamp
 import io.github.omochice.pinosu.feature.comment.domain.model.Comment
 import io.github.omochice.pinosu.feature.comment.presentation.viewmodel.BookmarkDetailUiState
@@ -66,6 +67,8 @@ import kotlinx.serialization.json.Json
  * @param onOpenUrlFailed Callback when opening a URL fails
  * @param isReadOnly Whether to hide comment input for read-only login
  * @param onEditBookmark Callback when edit button is clicked, or null to hide the button
+ * @param onCopyNostrLink Callback notified with the encoded nostr:nevent1 URI when "Copy nostr
+ *   link" is selected on a kind-1111 comment
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,6 +82,7 @@ fun BookmarkDetailScreen(
     onOpenUrlFailed: () -> Unit = {},
     isReadOnly: Boolean = false,
     onEditBookmark: (() -> Unit)? = null,
+    onCopyNostrLink: (String) -> Unit = {},
 ) {
   Scaffold(
       topBar = {
@@ -119,7 +123,8 @@ fun BookmarkDetailScreen(
             uiState = uiState,
             bookmarkInfo = bookmarkInfo,
             paddingValues = paddingValues,
-            onOpenUrlFailed = onOpenUrlFailed)
+            onOpenUrlFailed = onOpenUrlFailed,
+            onCopyNostrLink = onCopyNostrLink)
 
         uiState.error?.let { error ->
           ErrorDialog(message = error.asString(), onDismiss = onDismissError)
@@ -133,10 +138,8 @@ private fun BookmarkDetailContent(
     bookmarkInfo: BookmarkInfo,
     paddingValues: PaddingValues,
     onOpenUrlFailed: () -> Unit,
+    onCopyNostrLink: (String) -> Unit,
 ) {
-  val clipboardManager = LocalClipboardManager.current
-  val json = remember { Json { prettyPrint = true } }
-
   if (uiState.isLoading) {
     Box(
         modifier = Modifier.fillMaxSize().padding(paddingValues),
@@ -167,24 +170,47 @@ private fun BookmarkDetailContent(
             }
           } else {
             items(uiState.comments, key = { it.id }) { comment ->
-              val profileUrl = uiState.profiles[comment.authorPubkey]?.picture
-              if (comment.kind == Comment.KIND_TEXT_NOTE) {
-                QuoteCard(comment = comment, profileImageUrl = profileUrl)
-              } else {
-                CommentCard(
-                    comment = comment,
-                    profileImageUrl = profileUrl,
-                    onCopyContent = { content ->
-                      clipboardManager.setText(AnnotatedString(content))
-                    },
-                    onCopyRawJson =
-                        comment.event?.let { event ->
-                          { clipboardManager.setText(AnnotatedString(json.encodeToString(event))) }
-                        })
-              }
+              CommentRow(
+                  comment = comment,
+                  profileImageUrl = uiState.profiles[comment.authorPubkey]?.picture,
+                  onCopyNostrLink = onCopyNostrLink)
             }
           }
         }
+  }
+}
+
+@Composable
+private fun CommentRow(
+    comment: Comment,
+    profileImageUrl: String?,
+    onCopyNostrLink: (String) -> Unit,
+) {
+  val clipboardManager = LocalClipboardManager.current
+  val json = remember { Json { prettyPrint = true } }
+  val encoder = remember { Nip19EventEncoder() }
+
+  if (comment.kind == Comment.KIND_TEXT_NOTE) {
+    QuoteCard(comment = comment, profileImageUrl = profileImageUrl)
+  } else {
+    CommentCard(
+        comment = comment,
+        profileImageUrl = profileImageUrl,
+        onCopyContent = { content -> clipboardManager.setText(AnnotatedString(content)) },
+        onCopyRawJson =
+            comment.event?.let { event ->
+              { clipboardManager.setText(AnnotatedString(json.encodeToString(event))) }
+            },
+        onCopyNostrLink =
+            comment.event?.let { event ->
+              {
+                val encoded =
+                    encoder.encodeNEvent(
+                        eventId = event.id, pubkey = event.pubkey, kind = event.kind)
+                clipboardManager.setText(AnnotatedString(encoded))
+                onCopyNostrLink(encoded)
+              }
+            })
   }
 }
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -196,10 +195,15 @@ private fun CommentRow(
     CommentCard(
         comment = comment,
         profileImageUrl = profileImageUrl,
-        onCopyContent = { content -> clipboardManager.setText(AnnotatedString(content)) },
+        onCopyContent = { content ->
+          clipboardManager.setClip(ClipEntry(ClipData.newPlainText("content", content)))
+        },
         onCopyRawJson =
             comment.event?.let { event ->
-              { clipboardManager.setText(AnnotatedString(sharedJson.encodeToString(event))) }
+              {
+                clipboardManager.setClip(
+                    ClipEntry(ClipData.newPlainText("rawJson", sharedJson.encodeToString(event))))
+              }
             },
         onCopyNostrLink =
             comment.event?.let { event ->

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
@@ -1,5 +1,6 @@
 package io.github.omochice.pinosu.feature.comment.presentation.ui
 
+import android.content.ClipData
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -36,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
@@ -54,19 +54,8 @@ import io.github.omochice.pinosu.ui.component.ErrorDialog
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-/**
- * Shared JSON serializer for the bookmark detail screen.
- *
- * Hoisted to file scope so the prettyPrint configuration is allocated once for the entire app
- * rather than per LazyColumn row.
- */
 private val sharedJson = Json { prettyPrint = true }
 
-/**
- * Shared NIP-19 encoder for the bookmark detail screen.
- *
- * Stateless and thread-safe; hoisted to avoid per-row re-allocation when the comment list scrolls.
- */
 private val sharedEncoder = Nip19EventEncoder()
 
 /**

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
@@ -207,7 +207,7 @@ private fun CommentRow(
                 val encoded =
                     sharedEncoder.encodeNEvent(
                         eventId = event.id, pubkey = event.pubkey, kind = event.kind)
-                clipboardManager.setText(AnnotatedString(encoded))
+                clipboardManager.setClip(ClipEntry(ClipData.newPlainText("nostrLink", encoded)))
                 onCopyNostrLink(encoded)
               }
             })

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -54,6 +53,21 @@ import io.github.omochice.pinosu.feature.comment.presentation.viewmodel.Bookmark
 import io.github.omochice.pinosu.ui.component.ErrorDialog
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+
+/**
+ * Shared JSON serializer for the bookmark detail screen.
+ *
+ * Hoisted to file scope so the prettyPrint configuration is allocated once for the entire app
+ * rather than per LazyColumn row.
+ */
+private val sharedJson = Json { prettyPrint = true }
+
+/**
+ * Shared NIP-19 encoder for the bookmark detail screen.
+ *
+ * Stateless and thread-safe; hoisted to avoid per-row re-allocation when the comment list scrolls.
+ */
+private val sharedEncoder = Nip19EventEncoder()
 
 /**
  * Bookmark detail screen showing bookmark info and comments
@@ -187,9 +201,6 @@ private fun CommentRow(
     onCopyNostrLink: (String) -> Unit,
 ) {
   val clipboardManager = LocalClipboardManager.current
-  val json = remember { Json { prettyPrint = true } }
-  val encoder = remember { Nip19EventEncoder() }
-
   if (comment.kind == Comment.KIND_TEXT_NOTE) {
     QuoteCard(comment = comment, profileImageUrl = profileImageUrl)
   } else {
@@ -199,13 +210,13 @@ private fun CommentRow(
         onCopyContent = { content -> clipboardManager.setText(AnnotatedString(content)) },
         onCopyRawJson =
             comment.event?.let { event ->
-              { clipboardManager.setText(AnnotatedString(json.encodeToString(event))) }
+              { clipboardManager.setText(AnnotatedString(sharedJson.encodeToString(event))) }
             },
         onCopyNostrLink =
             comment.event?.let { event ->
               {
                 val encoded =
-                    encoder.encodeNEvent(
+                    sharedEncoder.encodeNEvent(
                         eventId = event.id, pubkey = event.pubkey, kind = event.kind)
                 clipboardManager.setText(AnnotatedString(encoded))
                 onCopyNostrLink(encoded)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
@@ -36,6 +36,7 @@ import io.github.omochice.pinosu.feature.comment.domain.model.Comment
  * @param onCopyContent Called when the user selects "Copy content"
  * @param profileImageUrl Profile image URL for the comment author, or null for fallback icon
  * @param onCopyRawJson Called when the user selects "Copy raw JSON", or null to hide the option
+ * @param onCopyNostrLink Called when the user selects "Copy nostr link", or null to hide the option
  */
 @Composable
 internal fun CommentCard(
@@ -43,6 +44,7 @@ internal fun CommentCard(
     onCopyContent: (String) -> Unit,
     profileImageUrl: String? = null,
     onCopyRawJson: (() -> Unit)? = null,
+    onCopyNostrLink: (() -> Unit)? = null,
 ) {
   var showMenu by remember { mutableStateOf(false) }
 
@@ -79,6 +81,14 @@ internal fun CommentCard(
             text = { Text(stringResource(R.string.menu_copy_raw_json)) },
             onClick = {
               onCopyRawJson()
+              showMenu = false
+            })
+      }
+      if (onCopyNostrLink != null) {
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
+            onClick = {
+              onCopyNostrLink()
               showMenu = false
             })
       }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -23,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpOffset
@@ -52,9 +54,10 @@ internal fun CommentCard(
 ) {
   var showMenu by remember { mutableStateOf(false) }
   var pressOffset by remember { mutableStateOf(Offset.Zero) }
+  var anchorHeightPx by remember { mutableIntStateOf(0) }
   val density = LocalDensity.current
 
-  Box {
+  Box(modifier = Modifier.onGloballyPositioned { anchorHeightPx = it.size.height }) {
     Card(
         modifier =
             Modifier.fillMaxWidth().pointerInput(Unit) {
@@ -66,45 +69,53 @@ internal fun CommentCard(
             },
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
-          Column(modifier = Modifier.padding(12.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-              ProfileAvatar(
-                  imageUrl = profileImageUrl,
-                  contentDescription = stringResource(R.string.cd_commenter_avatar),
-                  size = 24.dp,
-              )
-              Spacer(modifier = Modifier.width(8.dp))
-              Column(modifier = Modifier.weight(1f)) { CommentBody(comment = comment) }
-            }
-          }
+          CommentCardBody(comment = comment, profileImageUrl = profileImageUrl)
         }
 
     DropdownMenu(
         expanded = showMenu,
         onDismissRequest = { showMenu = false },
-        offset = with(density) { DpOffset(pressOffset.x.toDp(), pressOffset.y.toDp()) }) {
+        offset =
+            with(density) {
+              DpOffset(pressOffset.x.toDp(), (pressOffset.y - anchorHeightPx).toDp())
+            }) {
           DropdownMenuItem(
               text = { Text(stringResource(R.string.menu_copy_content)) },
               onClick = {
                 onCopyContent(comment.content)
                 showMenu = false
               })
-          if (onCopyRawJson != null) {
+          onCopyRawJson?.let { handler ->
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.menu_copy_raw_json)) },
                 onClick = {
-                  onCopyRawJson()
+                  handler()
                   showMenu = false
                 })
           }
-          if (onCopyNostrLink != null) {
+          onCopyNostrLink?.let { handler ->
             DropdownMenuItem(
                 text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
                 onClick = {
-                  onCopyNostrLink()
+                  handler()
                   showMenu = false
                 })
           }
         }
+  }
+}
+
+@Composable
+private fun CommentCardBody(comment: Comment, profileImageUrl: String?) {
+  Column(modifier = Modifier.padding(12.dp)) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      ProfileAvatar(
+          imageUrl = profileImageUrl,
+          contentDescription = stringResource(R.string.cd_commenter_avatar),
+          size = 24.dp,
+      )
+      Spacer(modifier = Modifier.width(8.dp))
+      Column(modifier = Modifier.weight(1f)) { CommentBody(comment = comment) }
+    }
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
@@ -30,7 +30,8 @@ import io.github.omochice.pinosu.feature.comment.domain.model.Comment
 /**
  * Card for displaying a NIP-22 kind 1111 comment
  *
- * Long-press shows a context menu to copy the comment content or raw event JSON.
+ * Long-press shows a context menu to copy the comment content, the raw event JSON, or a NIP-19
+ * `nostr:nevent1...` link to the comment.
  *
  * @param comment The comment to display
  * @param onCopyContent Called when the user selects "Copy content"

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
@@ -21,8 +21,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.feature.comment.domain.model.Comment
@@ -48,12 +51,18 @@ internal fun CommentCard(
     onCopyNostrLink: (() -> Unit)? = null,
 ) {
   var showMenu by remember { mutableStateOf(false) }
+  var pressOffset by remember { mutableStateOf(Offset.Zero) }
+  val density = LocalDensity.current
 
   Box {
     Card(
         modifier =
             Modifier.fillMaxWidth().pointerInput(Unit) {
-              detectTapGestures(onLongPress = { showMenu = true })
+              detectTapGestures(
+                  onLongPress = { offset ->
+                    pressOffset = offset
+                    showMenu = true
+                  })
             },
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
@@ -70,29 +79,32 @@ internal fun CommentCard(
           }
         }
 
-    DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
-      DropdownMenuItem(
-          text = { Text(stringResource(R.string.menu_copy_content)) },
-          onClick = {
-            onCopyContent(comment.content)
-            showMenu = false
-          })
-      if (onCopyRawJson != null) {
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.menu_copy_raw_json)) },
-            onClick = {
-              onCopyRawJson()
-              showMenu = false
-            })
-      }
-      if (onCopyNostrLink != null) {
-        DropdownMenuItem(
-            text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
-            onClick = {
-              onCopyNostrLink()
-              showMenu = false
-            })
-      }
-    }
+    DropdownMenu(
+        expanded = showMenu,
+        onDismissRequest = { showMenu = false },
+        offset = with(density) { DpOffset(pressOffset.x.toDp(), pressOffset.y.toDp()) }) {
+          DropdownMenuItem(
+              text = { Text(stringResource(R.string.menu_copy_content)) },
+              onClick = {
+                onCopyContent(comment.content)
+                showMenu = false
+              })
+          if (onCopyRawJson != null) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.menu_copy_raw_json)) },
+                onClick = {
+                  onCopyRawJson()
+                  showMenu = false
+                })
+          }
+          if (onCopyNostrLink != null) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
+                onClick = {
+                  onCopyNostrLink()
+                  showMenu = false
+                })
+          }
+        }
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
@@ -16,7 +17,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -24,10 +24,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.feature.comment.domain.model.Comment
@@ -54,10 +52,8 @@ internal fun CommentCard(
 ) {
   var showMenu by remember { mutableStateOf(false) }
   var pressOffset by remember { mutableStateOf(Offset.Zero) }
-  var anchorHeightPx by remember { mutableIntStateOf(0) }
-  val density = LocalDensity.current
 
-  Box(modifier = Modifier.onGloballyPositioned { anchorHeightPx = it.size.height }) {
+  Box {
     Card(
         modifier =
             Modifier.fillMaxWidth().pointerInput(Unit) {
@@ -72,36 +68,32 @@ internal fun CommentCard(
           CommentCardBody(comment = comment, profileImageUrl = profileImageUrl)
         }
 
-    DropdownMenu(
-        expanded = showMenu,
-        onDismissRequest = { showMenu = false },
-        offset =
-            with(density) {
-              DpOffset(pressOffset.x.toDp(), (pressOffset.y - anchorHeightPx).toDp())
-            }) {
+    Box(modifier = Modifier.offset { IntOffset(pressOffset.x.toInt(), pressOffset.y.toInt()) }) {
+      DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.menu_copy_content)) },
+            onClick = {
+              onCopyContent(comment.content)
+              showMenu = false
+            })
+        onCopyRawJson?.let { handler ->
           DropdownMenuItem(
-              text = { Text(stringResource(R.string.menu_copy_content)) },
+              text = { Text(stringResource(R.string.menu_copy_raw_json)) },
               onClick = {
-                onCopyContent(comment.content)
+                handler()
                 showMenu = false
               })
-          onCopyRawJson?.let { handler ->
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.menu_copy_raw_json)) },
-                onClick = {
-                  handler()
-                  showMenu = false
-                })
-          }
-          onCopyNostrLink?.let { handler ->
-            DropdownMenuItem(
-                text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
-                onClick = {
-                  handler()
-                  showMenu = false
-                })
-          }
         }
+        onCopyNostrLink?.let { handler ->
+          DropdownMenuItem(
+              text = { Text(stringResource(R.string.menu_copy_nostr_link)) },
+              onClick = {
+                handler()
+                showMenu = false
+              })
+        }
+      }
+    }
   }
 }
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -99,4 +99,5 @@
 
     <string name="menu_copy_content">内容をコピー</string>
     <string name="menu_copy_raw_json">Raw JSONをコピー</string>
+    <string name="menu_copy_nostr_link">Nostrリンクをコピー</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,5 +103,6 @@
 
     <string name="menu_copy_content">Copy content</string>
     <string name="menu_copy_raw_json">Copy raw JSON</string>
+    <string name="menu_copy_nostr_link">Copy nostr link</string>
 
 </resources>

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
@@ -1,6 +1,10 @@
 package io.github.omochice.pinosu.core.nip.nip19
 
+import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
+import com.vitorpamplona.quartz.nip19Bech32.entities.NAddress
 import io.github.omochice.pinosu.core.nip.nipb0.NipB0
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -18,5 +22,19 @@ class Nip19EventEncoderTest {
     assertTrue(
         "Encoded naddr should start with nostr:naddr1 but was '$result'",
         result.startsWith("nostr:naddr1"))
+  }
+
+  @Test
+  fun `encodeNAddr output decodes back to original kind pubkey and dTag`() {
+    val pubkey = "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"
+    val dTag = "bookmark-id-001"
+
+    val encoded = encoder.encodeNAddr(kind = NipB0.KIND_BOOKMARK_LIST, pubkey = pubkey, dTag = dTag)
+
+    val decoded = Nip19Parser.uriToRoute(encoded)?.entity as? NAddress
+    assertNotNull("Encoded naddr should be decodable", decoded)
+    assertEquals(NipB0.KIND_BOOKMARK_LIST, decoded?.kind)
+    assertEquals(pubkey, decoded?.author)
+    assertEquals(dTag, decoded?.dTag)
   }
 }

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
@@ -1,5 +1,6 @@
 package io.github.omochice.pinosu.core.nip.nip19
 
+import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -9,11 +10,10 @@ class Nip19EventEncoderTest {
 
   @Test
   fun `encodeNAddr returns string starting with nostr naddr1`() {
-    val kind = 39701
     val pubkey = "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"
     val dTag = "bookmark-id-001"
 
-    val result = encoder.encodeNAddr(kind = kind, pubkey = pubkey, dTag = dTag)
+    val result = encoder.encodeNAddr(kind = NipB0.KIND_BOOKMARK_LIST, pubkey = pubkey, dTag = dTag)
 
     assertTrue(
         "Encoded naddr should start with nostr:naddr1 but was '$result'",

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
@@ -2,6 +2,7 @@ package io.github.omochice.pinosu.core.nip.nip19
 
 import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
 import com.vitorpamplona.quartz.nip19Bech32.entities.NAddress
+import io.github.omochice.pinosu.core.nip.nip22.Nip22
 import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -36,5 +37,17 @@ class Nip19EventEncoderTest {
     assertEquals(NipB0.KIND_BOOKMARK_LIST, decoded?.kind)
     assertEquals(pubkey, decoded?.author)
     assertEquals(dTag, decoded?.dTag)
+  }
+
+  @Test
+  fun `encodeNEvent returns string starting with nostr nevent1`() {
+    val eventId = "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"
+    val pubkey = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+    val result = encoder.encodeNEvent(eventId = eventId, pubkey = pubkey, kind = Nip22.KIND_COMMENT)
+
+    assertTrue(
+        "Encoded nevent should start with nostr:nevent1 but was '$result'",
+        result.startsWith("nostr:nevent1"))
   }
 }

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
@@ -2,6 +2,7 @@ package io.github.omochice.pinosu.core.nip.nip19
 
 import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
 import com.vitorpamplona.quartz.nip19Bech32.entities.NAddress
+import com.vitorpamplona.quartz.nip19Bech32.entities.NEvent
 import io.github.omochice.pinosu.core.nip.nip22.Nip22
 import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import org.junit.Assert.assertEquals
@@ -49,5 +50,20 @@ class Nip19EventEncoderTest {
     assertTrue(
         "Encoded nevent should start with nostr:nevent1 but was '$result'",
         result.startsWith("nostr:nevent1"))
+  }
+
+  @Test
+  fun `encodeNEvent output decodes back to original event ID pubkey and kind`() {
+    val eventId = "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"
+    val pubkey = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+    val encoded =
+        encoder.encodeNEvent(eventId = eventId, pubkey = pubkey, kind = Nip22.KIND_COMMENT)
+
+    val decoded = Nip19Parser.uriToRoute(encoded)?.entity as? NEvent
+    assertNotNull("Encoded nevent should be decodable", decoded)
+    assertEquals(eventId, decoded?.hex)
+    assertEquals(pubkey, decoded?.author)
+    assertEquals(Nip22.KIND_COMMENT, decoded?.kind)
   }
 }

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
@@ -1,0 +1,22 @@
+package io.github.omochice.pinosu.core.nip.nip19
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Nip19EventEncoderTest {
+
+  private val encoder = Nip19EventEncoder()
+
+  @Test
+  fun `encodeNAddr returns string starting with nostr naddr1`() {
+    val kind = 39701
+    val pubkey = "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"
+    val dTag = "bookmark-id-001"
+
+    val result = encoder.encodeNAddr(kind = kind, pubkey = pubkey, dTag = dTag)
+
+    assertTrue(
+        "Encoded naddr should start with nostr:naddr1 but was '$result'",
+        result.startsWith("nostr:naddr1"))
+  }
+}

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventEncoderTest.kt
@@ -6,7 +6,6 @@ import com.vitorpamplona.quartz.nip19Bech32.entities.NEvent
 import io.github.omochice.pinosu.core.nip.nip22.Nip22
 import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -33,11 +32,13 @@ class Nip19EventEncoderTest {
 
     val encoded = encoder.encodeNAddr(kind = NipB0.KIND_BOOKMARK_LIST, pubkey = pubkey, dTag = dTag)
 
-    val decoded = Nip19Parser.uriToRoute(encoded)?.entity as? NAddress
-    assertNotNull("Encoded naddr should be decodable", decoded)
-    assertEquals(NipB0.KIND_BOOKMARK_LIST, decoded?.kind)
-    assertEquals(pubkey, decoded?.author)
-    assertEquals(dTag, decoded?.dTag)
+    val decoded =
+        checkNotNull(Nip19Parser.uriToRoute(encoded)?.entity as? NAddress) {
+          "Encoded naddr should be decodable"
+        }
+    assertEquals(NipB0.KIND_BOOKMARK_LIST, decoded.kind)
+    assertEquals(pubkey, decoded.author)
+    assertEquals(dTag, decoded.dTag)
   }
 
   @Test
@@ -60,10 +61,12 @@ class Nip19EventEncoderTest {
     val encoded =
         encoder.encodeNEvent(eventId = eventId, pubkey = pubkey, kind = Nip22.KIND_COMMENT)
 
-    val decoded = Nip19Parser.uriToRoute(encoded)?.entity as? NEvent
-    assertNotNull("Encoded nevent should be decodable", decoded)
-    assertEquals(eventId, decoded?.hex)
-    assertEquals(pubkey, decoded?.author)
-    assertEquals(Nip22.KIND_COMMENT, decoded?.kind)
+    val decoded =
+        checkNotNull(Nip19Parser.uriToRoute(encoded)?.entity as? NEvent) {
+          "Encoded nevent should be decodable"
+        }
+    assertEquals(eventId, decoded.hex)
+    assertEquals(pubkey, decoded.author)
+    assertEquals(Nip22.KIND_COMMENT, decoded.kind)
   }
 }


### PR DESCRIPTION
## Summary

Long-pressing a bookmark or a kind-1111 comment now surfaces a "Copy nostr link" item that copies a NIP-19 `nostr:` URI to the clipboard.

## Details

The long-press UX on bookmark cards used to copy the raw event JSON immediately and silently, with no menu. Comment cards already used a dropdown menu for "Copy content" / "Copy raw JSON". This change unifies the two surfaces around the dropdown menu pattern and adds a third action that emits a NIP-19 reference suitable for sharing into other Nostr clients.

For the NIP-19 form, kind 39701 (NIP-B0 bookmarks) is a parameterized replaceable event, so it is encoded as `naddr` — sharing the canonical address survives bookmark updates rather than pinning a specific event ID. Kind 1111 (NIP-22 comments) is a regular event and is encoded as `nevent`. Encoding is delegated to a new `Nip19EventEncoder` that wraps Quartz's `NAddress.create` / `NEvent.create`, with no relay hint embedded for the initial implementation.

Menu items appear only when their action is meaningful: "Copy raw JSON" is hidden when the bookmark has no rawJson, and "Copy nostr link" is hidden when the bookmark lacks a `d` tag or the comment lacks a backing event. The `nostr:` URI prefix is included so receiving clients can resolve the link as a NIP-21 URI.

## Confirmation

- Long-press a bookmark on the bookmark list. Verify the dropdown shows both "Copy raw JSON" and "Copy nostr link", and that selecting the latter places a `nostr:naddr1…` string on the clipboard.
- Open a bookmark detail screen with at least one kind-1111 comment. Long-press the comment and verify the menu now includes "Copy nostr link" producing a `nostr:nevent1…` string.
- Confirm a synthetic author comment (the one rendered from the bookmark itself, with no underlying event) does not show "Copy nostr link" in its menu.
- Run `devbox run ./gradlew detekt test connectedAndroidTest`.

## Limitation

- Relay hints are intentionally not encoded into the TLV payload. Recipients must rely on their own relay set to resolve the reference. Adding hints (from the user's NIP-65 relays or the actual seen-on relay) is a non-breaking follow-up.
- The new "Copy nostr link" label is hard-coded English/Japanese; no abbreviation is applied for narrow screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long-press menus on bookmarks, list/grid items, and comments open at the press location and offer conditional actions: "Copy nostr link" (copies a nostr: URI) and "Copy raw JSON"; menus dismiss after selection.

* **Localization**
  * Added English and Japanese strings for the "Copy nostr link" menu item.

* **Tests**
  * Added UI tests covering long-press menu behavior and unit tests validating NIP‑19 nostr link encoding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Omochice/Pinosu/pull/481)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->