### PR TITLE
test: migrate createComposeRule to v2 API

### DIFF
--- a/app/src/androidTest/java/io/github/omochice/pinosu/NavigationTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/NavigationTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.hilt.android.testing.HiltAndroidRule

--- a/app/src/androidTest/java/io/github/omochice/pinosu/ShareIntentNavigationTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/ShareIntentNavigationTest.kt
@@ -3,7 +3,7 @@ package io.github.omochice.pinosu
 import android.app.Activity
 import android.content.Intent
 import androidx.compose.ui.test.*
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.lifecycle.ViewModelProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.hilt.android.testing.BindValue

--- a/app/src/androidTest/java/io/github/omochice/pinosu/UserFlowTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/UserFlowTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu
 
 import androidx.compose.ui.test.*
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/appinfo/presentation/ui/AppInfoScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/appinfo/presentation/ui/AppInfoScreenTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/auth/presentation/integration/ActivityResultIntegrationTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/auth/presentation/integration/ActivityResultIntegrationTest.kt
@@ -1,6 +1,6 @@
 package io.github.omochice.pinosu.feature.auth.presentation.integration
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/auth/presentation/ui/LoginScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/auth/presentation/ui/LoginScreenTest.kt
@@ -2,7 +2,7 @@ package io.github.omochice.pinosu.feature.auth.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkItemCardTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
@@ -1,6 +1,6 @@
 package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenReadOnlyTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenReadOnlyTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
@@ -1,6 +1,6 @@
 package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/BookmarkDetailScreenTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentBodyTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentBodyTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu.feature.comment.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import io.github.omochice.pinosu.core.timestamp.formatTimestamp
 import io.github.omochice.pinosu.feature.comment.domain.model.Comment

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCardTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/CommentCardTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu.feature.comment.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/ProfileAvatarTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/ProfileAvatarTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu.feature.comment.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import kotlin.test.Test
 import org.junit.Rule

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/QuoteCardTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/comment/presentation/ui/QuoteCardTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu.feature.comment.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import io.github.omochice.pinosu.R

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/main/presentation/ui/MainScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/main/presentation/ui/MainScreenTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu.feature.main.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import io.github.omochice.pinosu.R

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreenTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/postbookmark/presentation/ui/PostBookmarkScreenTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu.feature.postbookmark.presentation.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import io.github.omochice.pinosu.R

--- a/app/src/androidTest/java/io/github/omochice/pinosu/ui/drawer/AppDrawerTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/ui/drawer/AppDrawerTest.kt
@@ -1,7 +1,7 @@
 package io.github.omochice.pinosu.ui.drawer
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import io.github.omochice.pinosu.R


### PR DESCRIPTION
## Summary

Switch the import for `createComposeRule` and `createAndroidComposeRule` from the deprecated v1 entry points to the v2 package across all 18 affected `androidTest` files, eliminating the deprecation warning surfaced during `connectedAndroidTest`.

## Details

The v1 `androidx.compose.ui.test.junit4.{createComposeRule, createAndroidComposeRule}` factories have been deprecated in favor of the v2 versions under `androidx.compose.ui.test.junit4.v2`. The v2 APIs run composition on `StandardTestDispatcher`, which queues coroutine work instead of executing it eagerly under `UnconfinedTestDispatcher`. This brings test behavior in line with `runTest` semantics and gives explicit control over coroutine ordering.

The original issue enumerated 14 files, but four `MainActivity`-based integration tests (`UserFlowTest`, `NavigationTest`, `ShareIntentNavigationTest`, `ActivityResultIntegrationTest`) also relied on the deprecated `createAndroidComposeRule`. They were included in this PR to avoid leaving the codebase half-migrated. The v2 functions retain identical signatures (parameterless overload and the `<reified A : ComponentActivity>` form), so no call-site rewrites were required. `connectedAndroidTest` passed without any synchronization adjustments, confirming no existing test depended on the eager dispatcher.

## Confirmation

- Run `devbox run ./gradlew :app:compileDebugAndroidTestKotlin` and confirm it builds.
- Run `devbox run ./gradlew :app:connectedAndroidTest` against an emulator/device and confirm 0 failures (2 pre-existing skipped tests are expected).
- `grep -rn "androidx\.compose\.ui\.test\.junit4\.\(createComposeRule\|createAndroidComposeRule\)" app/src/androidTest/` should return no matches; only `androidx.compose.ui.test.junit4.v2.*` remains.

## Limitation

No known limitations.

Closes #489