### PR TITLE
ci: publish releases to Zapstore

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,6 +76,20 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+      - name: Publish to zapstore
+        env:
+          ZSP_VERSION: 0.4.10
+        run: |
+          mkdir -p "${RUNNER_TEMP}/zsp-bin"
+          curl -fsSL -o "${RUNNER_TEMP}/zsp-bin/zsp" \
+            "https://github.com/zapstore/zsp/releases/download/v${ZSP_VERSION}/zsp-${ZSP_VERSION}-linux-amd64"
+          chmod +x "${RUNNER_TEMP}/zsp-bin/zsp"
+          echo "${RUNNER_TEMP}/zsp-bin" >> "$GITHUB_PATH"
+      - run: |
+          zsp publish --quiet --skip-preview zapstore.yaml
+        env:
+          SIGN_WITH: ${{ secrets.SIGN_WITH }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   increment-version-code:
     needs: release-please

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,20 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-      - name: Publish to zapstore
+
+  publish-zapstore:
+    needs: [release-please, build-release]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install zsp
         env:
           ZSP_VERSION: 0.4.10
         run: |
@@ -85,8 +98,8 @@ jobs:
             "https://github.com/zapstore/zsp/releases/download/v${ZSP_VERSION}/zsp-${ZSP_VERSION}-linux-amd64"
           chmod +x "${RUNNER_TEMP}/zsp-bin/zsp"
           echo "${RUNNER_TEMP}/zsp-bin" >> "$GITHUB_PATH"
-      - run: |
-          zsp publish --quiet --skip-preview zapstore.yaml
+      - name: Publish to zapstore
+        run: zsp publish --quiet --skip-preview zapstore.yaml
         env:
           SIGN_WITH: ${{ secrets.SIGN_WITH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,10 +91,12 @@ jobs:
       - name: Install zsp
         env:
           ZSP_VERSION: 0.4.10
+          ZSP_SHA256: a1f73e3f89935e53c0be2fb210fbe9a0da13f693a77627053a208332d8351394
         run: |
           mkdir -p "${RUNNER_TEMP}/zsp-bin"
           curl -fsSL -o "${RUNNER_TEMP}/zsp-bin/zsp" \
             "https://github.com/zapstore/zsp/releases/download/v${ZSP_VERSION}/zsp-${ZSP_VERSION}-linux-amd64"
+          echo "${ZSP_SHA256#sha256:}  ${RUNNER_TEMP}/zsp-bin/zsp" | sha256sum --check
           chmod +x "${RUNNER_TEMP}/zsp-bin/zsp"
           echo "${RUNNER_TEMP}/zsp-bin" >> "$GITHUB_PATH"
       - name: Publish to zapstore

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,8 +78,7 @@ jobs:
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
 
   publish-zapstore:
-    needs: [release-please, build-release]
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    needs: build-release
     timeout-minutes: 10
     runs-on: ubuntu-latest
     environment: release

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,19 @@
   extends: [
     "github>Omochice/personal-renovate-config#v1.13.0",
   ],
+  customManagers: [
+    {
+      customType: "jsonata",
+      fileFormat: "yaml",
+      managerFilePatterns: [
+        ".github/workflows/release.yaml",
+      ],
+      matchStrings: [
+        "jobs.*.steps[$exists(env.ZSP_VERSION)].{ 'currentValue': env.ZSP_VERSION }",
+      ],
+      depNameTemplate: "zapstore/zsp",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^v(?<version>.+)$",
+    },
+  ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,10 +11,10 @@
         ".github/workflows/release.yaml",
       ],
       matchStrings: [
-        "jobs.*.steps[$exists(env.ZSP_VERSION)].{ 'currentValue': env.ZSP_VERSION }",
+        "jobs.*.steps[$exists(env.ZSP_VERSION)].{ 'currentValue': env.ZSP_VERSION, 'currentDigest': env.ZSP_SHA256 }",
       ],
       depNameTemplate: "zapstore/zsp",
-      datasourceTemplate: "github-releases",
+      datasourceTemplate: "github-release-attachments",
       extractVersionTemplate: "^v(?<version>.+)$",
     },
   ],

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,0 +1,35 @@
+repository: https://github.com/Omochice/Pinosu
+summary: A decentralized web bookmark app for Android, powered by Nostr
+description: |
+  Pinosu is a decentralized web bookmark app for Android, powered by Nostr.
+  You keep full ownership of your data, with no central server.
+
+  Features:
+
+  - Save and organize web bookmarks
+  - Bookmarks stored as Nostr Kind 39701 (web bookmark) events
+  - Access from any Nostr-compatible client
+  - Sync across devices through Nostr relays
+
+  Requirements:
+
+  - A NIP-55 compatible signer app (e.g. Amber)
+metadata_sources:
+  - github
+pubkey: npub19qe9896nte5dwe54tqvupytwpla9yzzg45en2lneh37wullc63lqqavvh7
+license: zlib
+tags:
+  - nostr
+  - japan
+  - web_bookmark
+  - bookmark
+release_notes: CHANGELOG.md
+supported_nips:
+  - "01"
+  - "19"
+  - "22"
+  - "55"
+  - "65"
+  - "89"
+  - "B0"
+match: app-release.apk


### PR DESCRIPTION
## Summary

Publish Pinosu to Zapstore (a Nostr-based app store) automatically on each release.

## Details

Adds `zapstore.yaml` with explicit store metadata (summary, description, tags, license, supported NIPs, release notes), a release-workflow step that publishes the APK via a pinned `zsp` CLI signed with the `SIGN_WITH` secret, and a Renovate manager that keeps `zsp` up to date.

## Confirmation

A local offline `zsp` dry run parsed and verified the APK and generated valid events (kinds 32267 / 30063 / 3063); the signer pubkey matched the configured `pubkey`.

## Limitation

- The CI publish runs only on the next release and needs the `SIGN_WITH` secret.
- No screenshots (`images`) are configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)