### PR TITLE
feat: target Android 17 (API level 37)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,12 +34,12 @@ plugins {
 
 android {
   namespace = "io.github.omochice.pinosu"
-  compileSdk = 36
+  compileSdk = 37
 
   defaultConfig {
     applicationId = "io.github.omochice.pinosu"
     minSdk = 30
-    targetSdk = 36
+    targetSdk = 37
     versionCode = (versionJson["versionCode"] as? Number)?.toInt() ?: 1
     versionName = (versionJson["versionName"] as? String) ?: "0.1.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,6 +158,13 @@ dependencies {
   androidTestImplementation(libs.mockk.android)
   androidTestImplementation("com.google.dagger:hilt-android-testing:${libs.versions.hilt.get()}")
   kspAndroidTest("com.google.dagger:hilt-compiler:${libs.versions.hilt.get()}")
+
+  constraints {
+    androidTestImplementation(libs.androidx.test.espresso.core) {
+      because(
+          "espresso-core <3.7.0 calls the removed InputManager.getInstance and crashes on API 37")
+    }
+  }
 }
 
 kover {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ androidx-core-ktx = {group = "androidx.core", name = "core-ktx", version.ref = "
 junit = {group = "junit", name = "junit", version.ref = "junit"}
 androidx-junit = {group = "androidx.test.ext", name = "junit", version.ref = "junitVersion"}
 androidx-test-runner = {group = "androidx.test", name = "runner", version.ref = "testRunner"}
+androidx-test-espresso-core = {group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso"}
 material = {group = "com.google.android.material", name = "material", version.ref = "material"}
 androidx-navigation-compose = {group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose"}
 androidx-hilt-lifecycle-viewmodel-compose = {group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltNavigationCompose"}
@@ -62,6 +63,7 @@ detekt = "1.23.8"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 testRunner = "1.7.0"
+espresso = "3.7.0"
 material = "1.14.0"
 navigationCompose = "2.9.8"
 hiltNavigationCompose = "1.3.0"


### PR DESCRIPTION
## Summary

Raise compileSdk and targetSdk to 37 so the app targets Android 17, and keep the instrumented test suite runnable at that level.

## Details

targetSdk 37 applies Android 17 runtime behavior to users, so the bump is treated as a user-facing change; minSdk stays at 30 and AGP is unchanged.

Instrumented tests crash on API 37 because Compose ui-test pulls espresso-core 3.5.0, which calls the removed InputManager.getInstance; a dependency constraint raises espresso-core to 3.7.0 without adding a direct dependency the tests do not use.

## Confirmation

Ran detekt and JVM unit tests (BUILD SUCCESSFUL), and ran connectedDebugAndroidTest on a local API 37 emulator with 128 tests passing and the InputManager crash gone.

## Limitation

The CI instrumented-test emulator stays on API 34. The API 37 x86_64 image is only available as the 16 KB page-size google_apis_ps16k variant, which does not boot on GitHub-hosted runners (adb never connects and the boot times out), so on-device API 37 coverage is local-only for now. Raising the CI emulator to 37 is left for when that image boots reliably in CI.