### PR TITLE
build: declare dependencies via constraints and version catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,7 +133,7 @@ dependencies {
   implementation(libs.hilt.android)
   ksp(libs.hilt.compiler)
 
-  detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${libs.versions.detekt.get()}")
+  detektPlugins(libs.detekt.formatting)
 
   // Compose compiler plugin is applied module-wide; testFixtures needs the runtime on classpath
   testFixturesImplementation(platform(libs.androidx.compose.bom))
@@ -153,8 +153,8 @@ dependencies {
   androidTestImplementation(libs.androidx.test.runner)
   androidTestImplementation(libs.kotlinx.coroutines.test)
   androidTestImplementation(libs.mockk.android)
-  androidTestImplementation("com.google.dagger:hilt-android-testing:${libs.versions.hilt.get()}")
-  kspAndroidTest("com.google.dagger:hilt-compiler:${libs.versions.hilt.get()}")
+  androidTestImplementation(libs.hilt.android.testing)
+  kspAndroidTest(libs.hilt.compiler)
 
   constraints {
     androidTestImplementation(libs.androidx.test.espresso.core) {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,9 +132,6 @@ dependencies {
 
   implementation(libs.hilt.android)
   ksp(libs.hilt.compiler)
-  // Workaround for Hilt + Kotlin 2.3.0 metadata compatibility
-  // https://github.com/google/dagger/issues/5001
-  ksp(libs.kotlin.metadata.jvm)
 
   detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${libs.versions.detekt.get()}")
 
@@ -163,6 +160,11 @@ dependencies {
     androidTestImplementation(libs.androidx.test.espresso.core) {
       because(
           "espresso-core <3.7.0 calls the removed InputManager.getInstance and crashes on API 37")
+    }
+    ksp(libs.kotlin.metadata.jvm) {
+      because(
+          "hilt-compiler pulls an older kotlin-metadata-jvm that cannot read Kotlin 2.3+ metadata" +
+              " (https://github.com/google/dagger/issues/5001)")
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [libraries]
 androidx-core-ktx = {group = "androidx.core", name = "core-ktx", version.ref = "coreKtx"}
+detekt-formatting = {group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt"}
 junit = {group = "junit", name = "junit", version.ref = "junit"}
 androidx-junit = {group = "androidx.test.ext", name = "junit", version.ref = "junitVersion"}
 androidx-test-runner = {group = "androidx.test", name = "runner", version.ref = "testRunner"}
@@ -23,6 +24,7 @@ androidx-lifecycle-runtime-compose = {group = "androidx.lifecycle", name = "life
 androidx-activity-compose = {group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose"}
 quartz = {group = "com.vitorpamplona.quartz", name = "quartz", version.ref = "quartz"}
 hilt-android = {group = "com.google.dagger", name = "hilt-android", version.ref = "hilt"}
+hilt-android-testing = {group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt"}
 hilt-compiler = {group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt"}
 okhttp = {group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp"}
 jsoup = {group = "org.jsoup", name = "jsoup", version.ref = "jsoup"}


### PR DESCRIPTION
## Summary

Replace ad-hoc dependency pinning and string-notation dependency declarations with a dependency constraint and version catalog entries.

## Details

The kotlin-metadata-jvm workaround for dagger#5001 was a direct ksp dependency that existed only to raise the version pulled transitively by hilt-compiler, so it is now a constraint, matching the existing espresso-core pin.

detekt-formatting, hilt-android-testing, and the androidTest hilt-compiler were coordinate strings interpolating catalog versions, and are now catalog entries so Renovate and lint can see them.

## Confirmation

Confirmed via dependencyInsight that kotlin-metadata-jvm still resolves to 2.4.0 on the KSP classpath by the constraint.

Confirmed that :app:compileDebugKotlin and :app:compileDebugAndroidTestKotlin succeed and detektPlugins resolves detekt-formatting 1.23.8.

## Limitation

No known limitations.

https://claude.ai/code/session_018Cb93wX1qsaCd37oS55RTa