### PR TITLE
test: replace ArchUnit with Konsist for architecture tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -145,7 +145,7 @@ dependencies {
   testImplementation(libs.mockk)
   testImplementation(libs.robolectric)
   testImplementation(libs.kotlinx.coroutines.test)
-  testImplementation(libs.archunit)
+  testImplementation(libs.konsist)
   androidTestImplementation(testFixtures(project(":app")))
   androidTestImplementation(libs.kotlin.test)
   androidTestImplementation(libs.kotlin.test.junit)

--- a/app/src/test/java/io/github/omochice/pinosu/architecture/DependencyDirectionTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/architecture/DependencyDirectionTest.kt
@@ -1,44 +1,40 @@
 package io.github.omochice.pinosu.architecture
 
-import com.tngtech.archunit.core.importer.ImportOption
-import com.tngtech.archunit.junit.AnalyzeClasses
-import com.tngtech.archunit.junit.ArchTest
-import com.tngtech.archunit.junit.ArchUnitRunner
-import com.tngtech.archunit.lang.ArchRule
-import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
-import org.junit.runner.RunWith
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
+import com.lemonappdev.konsist.api.architecture.Layer
+import kotlin.test.Test
 
-@RunWith(ArchUnitRunner::class)
-@AnalyzeClasses(
-    packages = ["io.github.omochice.pinosu"],
-    importOptions = [ImportOption.DoNotIncludeTests::class],
-)
 class DependencyDirectionTest {
 
-  @ArchTest
-  val `core must not depend on feature`: ArchRule =
-      noClasses()
-          .that()
-          .resideInAPackage("io.github.omochice.pinosu.core..")
-          .should()
-          .dependOnClassesThat()
-          .resideInAPackage("io.github.omochice.pinosu.feature..")
+  @Test
+  fun `core must not depend on feature`() {
+    Konsist.scopeFromProduction().assertArchitecture {
+      val core = Layer("Core", "io.github.omochice.pinosu.core..")
+      val feature = Layer("Feature", "io.github.omochice.pinosu.feature..")
+      core.doesNotDependOn(feature)
+    }
+  }
 
-  @ArchTest
-  val `feature domain must not depend on data`: ArchRule =
-      noClasses()
-          .that()
-          .resideInAPackage("io.github.omochice.pinosu.feature.*.domain..")
-          .should()
-          .dependOnClassesThat()
-          .resideInAPackage("io.github.omochice.pinosu.feature.*.data..")
+  // Konsist Layer patterns allow ".." only at the start or end, so
+  // "feature.*.domain.." cannot be expressed directly. Segment-based patterns
+  // are equivalent here because domain/data/presentation packages exist only
+  // under feature.*.
+  @Test
+  fun `feature domain must not depend on data`() {
+    Konsist.scopeFromProduction().assertArchitecture {
+      val domain = Layer("Domain", "..domain..")
+      val data = Layer("Data", "..data..")
+      domain.doesNotDependOn(data)
+    }
+  }
 
-  @ArchTest
-  val `feature domain must not depend on presentation`: ArchRule =
-      noClasses()
-          .that()
-          .resideInAPackage("io.github.omochice.pinosu.feature.*.domain..")
-          .should()
-          .dependOnClassesThat()
-          .resideInAPackage("io.github.omochice.pinosu.feature.*.presentation..")
+  @Test
+  fun `feature domain must not depend on presentation`() {
+    Konsist.scopeFromProduction().assertArchitecture {
+      val domain = Layer("Domain", "..domain..")
+      val presentation = Layer("Presentation", "..presentation..")
+      domain.doesNotDependOn(presentation)
+    }
+  }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ okhttp = {group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp
 jsoup = {group = "org.jsoup", name = "jsoup", version.ref = "jsoup"}
 mockk = {group = "io.mockk", name = "mockk", version.ref = "mockk"}
 mockk-android = {group = "io.mockk", name = "mockk-android", version.ref = "mockk"}
-archunit = {group = "com.tngtech.archunit", name = "archunit-junit4", version.ref = "archunit"}
+konsist = {group = "com.lemonappdev", name = "konsist", version.ref = "konsist"}
 robolectric = {group = "org.robolectric", name = "robolectric", version.ref = "robolectric"}
 kotlinx-coroutines-android = {group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines"}
 kotlinx-coroutines-test = {group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines"}
@@ -85,4 +85,4 @@ aboutlibraries = "14.2.1"
 serializationJson = "1.11.0"
 tink = "1.22.0"
 coil = "3.5.0"
-archunit = "1.4.2"
+konsist = "0.17.3"


### PR DESCRIPTION
## Summary

Replace ArchUnit with Konsist for the architecture dependency-direction tests.

## Details

ArchUnit analyzes compiled bytecode, requires a dedicated JUnit runner, and has no Kotlin-aware API, while Konsist expresses the same three dependency-direction rules as plain Kotlin assertions.

Konsist Layer patterns do not support mid-package wildcards, so "feature.*.domain.." is expressed as "..domain..", which is equivalent here because domain/data/presentation packages exist only under feature.*.

## Confirmation

Ran the migrated test and detekt locally; all 3 tests executed and passed (tests="3" skipped="0").

Temporarily inverted one rule to confirm Konsist actually reports violations, then reverted it.

## Limitation

Konsist detects layer dependencies from import statements only, so a fully-qualified reference written without an import statement would not be caught, unlike ArchUnit's bytecode analysis.

https://claude.ai/code/session_018Cb93wX1qsaCd37oS55RTa