### PR TITLE
fix(bookmark): give Local and Global tabs independent per-tab queries

### DIFF
--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
@@ -46,9 +46,7 @@ class BookmarkScreenLongPressTest {
 
     composeTestRule.setContent {
       BookmarkScreen(
-          uiState =
-              BookmarkUiState(
-                  local = BookmarkTabState(items = listOf(sampleBookmark), isLoaded = true)),
+          uiState = BookmarkUiState(local = BookmarkTabState(items = listOf(sampleBookmark))),
           onRefresh = {},
           onLoad = {},
           onLongPressBookmark = { rawJson -> capturedRawJson = rawJson })
@@ -69,9 +67,7 @@ class BookmarkScreenLongPressTest {
 
     composeTestRule.setContent {
       BookmarkScreen(
-          uiState =
-              BookmarkUiState(
-                  local = BookmarkTabState(items = listOf(sampleBookmark), isLoaded = true)),
+          uiState = BookmarkUiState(local = BookmarkTabState(items = listOf(sampleBookmark))),
           onRefresh = {},
           onLoad = {},
           onCopyNostrLink = { encoded -> capturedNostrLink = encoded })
@@ -94,9 +90,7 @@ class BookmarkScreenLongPressTest {
 
     composeTestRule.setContent {
       BookmarkScreen(
-          uiState =
-              BookmarkUiState(
-                  local = BookmarkTabState(items = listOf(bookmarkWithoutDTag), isLoaded = true)),
+          uiState = BookmarkUiState(local = BookmarkTabState(items = listOf(bookmarkWithoutDTag))),
           onRefresh = {},
           onLoad = {})
     }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenLongPressTest.kt
@@ -9,6 +9,7 @@ import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.core.nip.nipb0.NipB0
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkedEvent
+import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkTabState
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState
 import io.github.omochice.pinosu.getTestString
 import kotlin.test.Test
@@ -47,10 +48,7 @@ class BookmarkScreenLongPressTest {
       BookmarkScreen(
           uiState =
               BookmarkUiState(
-                  isLoading = false,
-                  allBookmarks = listOf(sampleBookmark),
-                  userHexPubkey =
-                      "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"),
+                  local = BookmarkTabState(items = listOf(sampleBookmark), isLoaded = true)),
           onRefresh = {},
           onLoad = {},
           onLongPressBookmark = { rawJson -> capturedRawJson = rawJson })
@@ -73,10 +71,7 @@ class BookmarkScreenLongPressTest {
       BookmarkScreen(
           uiState =
               BookmarkUiState(
-                  isLoading = false,
-                  allBookmarks = listOf(sampleBookmark),
-                  userHexPubkey =
-                      "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"),
+                  local = BookmarkTabState(items = listOf(sampleBookmark), isLoaded = true)),
           onRefresh = {},
           onLoad = {},
           onCopyNostrLink = { encoded -> capturedNostrLink = encoded })
@@ -101,10 +96,7 @@ class BookmarkScreenLongPressTest {
       BookmarkScreen(
           uiState =
               BookmarkUiState(
-                  isLoading = false,
-                  allBookmarks = listOf(bookmarkWithoutDTag),
-                  userHexPubkey =
-                      "64381a1ad1ca81ccb4d264d48904387fc13251bb98d440e0ab4addb6997d7924"),
+                  local = BookmarkTabState(items = listOf(bookmarkWithoutDTag), isLoaded = true)),
           onRefresh = {},
           onLoad = {})
     }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenReadOnlyTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenReadOnlyTest.kt
@@ -21,11 +21,7 @@ class BookmarkScreenReadOnlyTest {
   @Test
   fun `FAB should be visible when not in read-only mode`() {
     composeTestRule.setContent {
-      BookmarkScreen(
-          uiState = BookmarkUiState(isLoading = false),
-          onRefresh = {},
-          onLoad = {},
-          isReadOnly = false)
+      BookmarkScreen(uiState = BookmarkUiState(), onRefresh = {}, onLoad = {}, isReadOnly = false)
     }
 
     composeTestRule
@@ -36,11 +32,7 @@ class BookmarkScreenReadOnlyTest {
   @Test
   fun `FAB should be hidden when in read-only mode`() {
     composeTestRule.setContent {
-      BookmarkScreen(
-          uiState = BookmarkUiState(isLoading = false),
-          onRefresh = {},
-          onLoad = {},
-          isReadOnly = true)
+      BookmarkScreen(uiState = BookmarkUiState(), onRefresh = {}, onLoad = {}, isReadOnly = true)
     }
 
     composeTestRule

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
@@ -57,8 +57,8 @@ class BookmarkScreenSwipeTest {
       BookmarkScreen(
           uiState =
               BookmarkUiState(
-                  local = BookmarkTabState(items = listOf(localBookmark), isLoaded = true),
-                  global = BookmarkTabState(items = listOf(globalBookmark), isLoaded = true),
+                  local = BookmarkTabState(items = listOf(localBookmark)),
+                  global = BookmarkTabState(items = listOf(globalBookmark)),
                   selectedTab = BookmarkFilterMode.Local),
           onRefresh = {},
           onLoad = {},
@@ -82,8 +82,8 @@ class BookmarkScreenSwipeTest {
       BookmarkScreen(
           uiState =
               BookmarkUiState(
-                  local = BookmarkTabState(items = listOf(localBookmark), isLoaded = true),
-                  global = BookmarkTabState(items = listOf(globalBookmark), isLoaded = true),
+                  local = BookmarkTabState(items = listOf(localBookmark)),
+                  global = BookmarkTabState(items = listOf(globalBookmark)),
                   selectedTab = BookmarkFilterMode.Global),
           onRefresh = {},
           onLoad = {},

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.swipeRight
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkedEvent
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkFilterMode
+import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkTabState
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -56,10 +57,9 @@ class BookmarkScreenSwipeTest {
       BookmarkScreen(
           uiState =
               BookmarkUiState(
-                  isLoading = false,
-                  allBookmarks = listOf(localBookmark, globalBookmark),
-                  selectedTab = BookmarkFilterMode.Local,
-                  userHexPubkey = "my-pubkey"),
+                  local = BookmarkTabState(items = listOf(localBookmark), isLoaded = true),
+                  global = BookmarkTabState(items = listOf(globalBookmark), isLoaded = true),
+                  selectedTab = BookmarkFilterMode.Local),
           onRefresh = {},
           onLoad = {},
           onTabSelected = { tab -> selectedTab = tab })
@@ -82,10 +82,9 @@ class BookmarkScreenSwipeTest {
       BookmarkScreen(
           uiState =
               BookmarkUiState(
-                  isLoading = false,
-                  allBookmarks = listOf(localBookmark, globalBookmark),
-                  selectedTab = BookmarkFilterMode.Global,
-                  userHexPubkey = "my-pubkey"),
+                  local = BookmarkTabState(items = listOf(localBookmark), isLoaded = true),
+                  global = BookmarkTabState(items = listOf(globalBookmark), isLoaded = true),
+                  selectedTab = BookmarkFilterMode.Global),
           onRefresh = {},
           onLoad = {},
           onTabSelected = { tab -> selectedTab = tab })

--- a/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/MainActivity.kt
@@ -348,15 +348,15 @@ fun PinosuApp(
 
                 BookmarkScreen(
                     uiState = bookmarkUiState,
-                    onRefresh = { bookmarkViewModel.loadBookmarks() },
-                    onLoad = { bookmarkViewModel.loadBookmarks() },
+                    onRefresh = { mode -> bookmarkViewModel.loadTab(mode, forceReload = true) },
+                    onLoad = { mode -> bookmarkViewModel.loadTab(mode) },
                     onOpenDrawer = { scope.launch { drawerState.open() } },
                     onTabSelected = { tab -> bookmarkViewModel.selectTab(tab) },
                     onAddBookmark = { navController.navigate(PostBookmark()) },
                     onBookmarkDetailNavigate = { bookmark ->
                       navigateToBookmarkDetail(navController, bookmark)
                     },
-                    onLoadMore = { bookmarkViewModel.loadMore() },
+                    onLoadMore = { mode -> bookmarkViewModel.loadMore(mode) },
                     isReadOnly = mainUiState.isReadOnly)
               }
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
@@ -47,43 +47,48 @@ constructor(
 ) : BookmarkRepository {
 
   /**
-   * Retrieve bookmark list for the specified public key
+   * Retrieve a bookmark list, optionally constrained to a single author
    *
-   * @param pubkey Nostr public key (Bech32-encoded format, starts with npub1)
-   * @param until Unix timestamp upper bound for pagination (exclusive), null for latest
+   * @param authorPubkey Nostr public key (Bech32-encoded format, starts with npub1) to constrain
+   *   the query to a single author (Local tab), or null to query all authors (Global tab)
+   * @param until Unix timestamp upper bound for pagination (inclusive per NIP-01), null for latest
    * @return Success(BookmarkList) if found, Success(null) if no bookmarks, Failure on error
    */
-  override suspend fun getBookmarkList(pubkey: String, until: Long?): Result<BookmarkList?> {
+  override suspend fun getBookmarkList(authorPubkey: String?, until: Long?): Result<BookmarkList?> {
     return try {
-      val hexPubkey =
-          Pubkey.parse(pubkey)?.hex
-              ?: return Result.failure(IllegalArgumentException("Invalid npub format"))
+      val hexPubkey = authorPubkey?.let { Pubkey.parse(it)?.hex }
+      if (authorPubkey != null && hexPubkey == null) {
+        return Result.failure(IllegalArgumentException("Invalid npub format"))
+      }
+      val authorsClause = hexPubkey?.let { ""","authors":["$it"]""" } ?: ""
 
       val relays = relayListProvider.getRelays()
       val untilClause = until?.let { ""","until":$it""" } ?: ""
-      val filter = """{"kinds":[${NipB0.KIND_BOOKMARK_LIST}],"limit":$PAGE_SIZE$untilClause}"""
+      val filter =
+          """{"kinds":[${NipB0.KIND_BOOKMARK_LIST}],"limit":$PAGE_SIZE$authorsClause$untilClause}"""
       val events = relayPool.subscribeWithTimeout(relays, filter, RelayPool.PER_RELAY_TIMEOUT_MS)
 
       if (events.isEmpty()) {
-        return Result.success(null)
+        Result.success(null)
+      } else {
+        val mostRecentEvent = events.maxBy { it.createdAt }
+
+        val allItems = coroutineScope {
+          events.map { event -> async { buildBookmarkItem(event) } }.awaitAll().filterNotNull()
+        }
+
+        val itemsWithEvents = allItems.sortedByDescending { it.event?.createdAt ?: 0L }
+        val encryptedContent =
+            if (mostRecentEvent.content.isNotEmpty()) mostRecentEvent.content else null
+
+        Result.success(
+            BookmarkList(
+                pubkey = mostRecentEvent.pubkey,
+                items = itemsWithEvents,
+                createdAt = mostRecentEvent.createdAt,
+                encryptedContent = encryptedContent,
+                hasMore = events.size >= PAGE_SIZE))
       }
-
-      val mostRecentEvent = events.maxBy { it.createdAt }
-
-      val allItems = coroutineScope {
-        events.map { event -> async { buildBookmarkItem(event) } }.awaitAll().filterNotNull()
-      }
-
-      val itemsWithEvents = allItems.sortedByDescending { it.event?.createdAt ?: 0L }
-      val encryptedContent =
-          if (mostRecentEvent.content.isNotEmpty()) mostRecentEvent.content else null
-
-      Result.success(
-          BookmarkList(
-              pubkey = mostRecentEvent.pubkey,
-              items = itemsWithEvents,
-              createdAt = mostRecentEvent.createdAt,
-              encryptedContent = encryptedContent))
     } catch (e: IOException) {
       Log.e(TAG, "Error getting bookmark list", e)
       Result.failure(e)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/model/Bookmark.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/model/Bookmark.kt
@@ -62,10 +62,14 @@ fun BookmarkedEvent.dTag(): String? =
  * @property items List of bookmarked events
  * @property createdAt Unix timestamp
  * @property encryptedContent Encrypted content (NIP-04) if present
+ * @property hasMore Whether the relay returned a full page, hinting more items may be fetched.
+ *   Based on the raw event count rather than the displayable item count so that events without a
+ *   usable URL do not prematurely stop pagination.
  */
 data class BookmarkList(
     val pubkey: String,
     val items: List<BookmarkItem>,
     val createdAt: Long,
     val encryptedContent: String? = null,
+    val hasMore: Boolean = false,
 )

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/repository/BookmarkRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/repository/BookmarkRepository.kt
@@ -11,13 +11,14 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkList
  */
 interface BookmarkRepository {
   /**
-   * Retrieve bookmark list for the specified public key
+   * Retrieve a bookmark list, optionally constrained to a single author
    *
-   * @param pubkey Nostr public key (Bech32-encoded format, starts with npub1)
-   * @param until Unix timestamp upper bound for pagination (exclusive), null for latest
+   * @param authorPubkey Nostr public key (Bech32-encoded format, starts with npub1) to constrain
+   *   the query to a single author (Local tab), or null to query all authors (Global tab)
+   * @param until Unix timestamp upper bound for pagination (inclusive per NIP-01), null for latest
    * @return Success(BookmarkList) if found, Success(null) if no bookmarks, Failure on error
    */
-  suspend fun getBookmarkList(pubkey: String, until: Long? = null): Result<BookmarkList?>
+  suspend fun getBookmarkList(authorPubkey: String?, until: Long? = null): Result<BookmarkList?>
 
   /**
    * Create an unsigned bookmark event

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/usecase/GetBookmarkListUseCase.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/usecase/GetBookmarkListUseCase.kt
@@ -9,11 +9,12 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkList
  */
 interface GetBookmarkListUseCase {
   /**
-   * Retrieve bookmark list for the specified public key
+   * Retrieve a bookmark list, optionally constrained to a single author
    *
-   * @param pubkey Nostr public key (Bech32-encoded format, starts with npub1)
-   * @param until Unix timestamp upper bound for pagination (exclusive), null for latest
+   * @param authorPubkey Nostr public key (Bech32-encoded format, starts with npub1) to constrain
+   *   the query to a single author (Local tab), or null to query all authors (Global tab)
+   * @param until Unix timestamp upper bound for pagination (inclusive per NIP-01), null for latest
    * @return Success(BookmarkList) if found, Success(null) if no bookmarks, Failure on error
    */
-  suspend operator fun invoke(pubkey: String, until: Long? = null): Result<BookmarkList?>
+  suspend operator fun invoke(authorPubkey: String?, until: Long? = null): Result<BookmarkList?>
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/usecase/GetBookmarkListUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/domain/usecase/GetBookmarkListUseCaseImpl.kt
@@ -16,12 +16,13 @@ class GetBookmarkListUseCaseImpl
 constructor(private val bookmarkRepository: BookmarkRepository) : GetBookmarkListUseCase {
 
   /**
-   * Retrieve bookmark list for the specified public key
+   * Retrieve a bookmark list, optionally constrained to a single author
    *
-   * @param pubkey Nostr public key (Bech32-encoded format, starts with npub1)
-   * @param until Unix timestamp upper bound for pagination (exclusive), null for latest
+   * @param authorPubkey Nostr public key (Bech32-encoded format, starts with npub1) to constrain
+   *   the query to a single author (Local tab), or null to query all authors (Global tab)
+   * @param until Unix timestamp upper bound for pagination (inclusive per NIP-01), null for latest
    * @return Success(BookmarkList) if found, Success(null) if no bookmarks, Failure on error
    */
-  override suspend fun invoke(pubkey: String, until: Long?): Result<BookmarkList?> =
-      bookmarkRepository.getBookmarkList(pubkey, until)
+  override suspend fun invoke(authorPubkey: String?, until: Long?): Result<BookmarkList?> =
+      bookmarkRepository.getBookmarkList(authorPubkey, until)
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkListCallbacks.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkListCallbacks.kt
@@ -1,21 +1,23 @@
 package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
+import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkFilterMode
 
 /**
  * Grouped callbacks for bookmark list user interactions
  *
- * @property onRefresh Callback when pull-to-refresh is triggered
+ * @property onRefresh Callback when pull-to-refresh is triggered, carrying the tab being refreshed
  * @property onClick Callback when a bookmark card is tapped
  * @property onLongPress Callback invoked when "Copy raw JSON" is selected from the long-press menu
  * @property onCopyNostrLink Callback invoked when "Copy nostr link" is selected from the long-press
  *   menu
- * @property onLoadMore Callback when user scrolls near the end of the list to load older bookmarks
+ * @property onLoadMore Callback when user scrolls near the end of the list, carrying the tab to
+ *   paginate
  */
 data class BookmarkListCallbacks(
-    val onRefresh: () -> Unit,
+    val onRefresh: (BookmarkFilterMode) -> Unit,
     val onClick: (BookmarkItem) -> Unit,
     val onLongPress: (BookmarkItem) -> Unit,
     val onCopyNostrLink: (BookmarkItem) -> Unit,
-    val onLoadMore: () -> Unit,
+    val onLoadMore: (BookmarkFilterMode) -> Unit,
 )

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -251,11 +251,18 @@ private fun BookmarkContent(
               }
             }
           }
-          tab.items.isEmpty() -> {
+          tab.items.isEmpty() && tab.isLoaded -> {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
               Text(
                   text = stringResource(R.string.message_no_bookmarks),
                   style = MaterialTheme.typography.bodyLarge)
+            }
+          }
+          tab.items.isEmpty() -> {
+            // Never-loaded tab (the pager is still settling before onLoad fires): show a spinner
+            // rather than briefly flashing the "no bookmarks" message.
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+              CircularProgressIndicator()
             }
           }
           else -> {
@@ -378,7 +385,10 @@ private fun BookmarkScreenLoadingPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun BookmarkScreenEmptyPreview() {
-  BookmarkScreen(uiState = BookmarkUiState(local = BookmarkTabState()), onRefresh = {}, onLoad = {})
+  BookmarkScreen(
+      uiState = BookmarkUiState(local = BookmarkTabState(isLoaded = true)),
+      onRefresh = {},
+      onLoad = {})
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -378,10 +378,7 @@ private fun BookmarkScreenLoadingPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun BookmarkScreenEmptyPreview() {
-  BookmarkScreen(
-      uiState = BookmarkUiState(local = BookmarkTabState(isLoaded = true)),
-      onRefresh = {},
-      onLoad = {})
+  BookmarkScreen(uiState = BookmarkUiState(local = BookmarkTabState()), onRefresh = {}, onLoad = {})
 }
 
 @Preview(showBackground = true)
@@ -419,7 +416,7 @@ private fun BookmarkScreenWithDataPreview() {
   BookmarkScreen(
       uiState =
           BookmarkUiState(
-              global = BookmarkTabState(items = sampleBookmarks, isLoaded = true),
+              global = BookmarkTabState(items = sampleBookmarks),
               selectedTab = BookmarkFilterMode.Global),
       onRefresh = {},
       onLoad = {})

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,6 +51,7 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkedEvent
 import io.github.omochice.pinosu.feature.bookmark.domain.model.dTag
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkFilterMode
+import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkTabState
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState
 import kotlinx.coroutines.flow.distinctUntilChanged
 
@@ -64,8 +64,8 @@ private val sharedEncoder = Nip19EventEncoder()
  * Supports both list and grid display modes based on user preference.
  *
  * @param uiState Bookmark screen UI state
- * @param onRefresh Callback when pull-to-refresh is triggered
- * @param onLoad Callback to load bookmarks on initial display
+ * @param onRefresh Callback when pull-to-refresh is triggered, carrying the tab to refresh
+ * @param onLoad Callback to lazily load a tab when it becomes visible, carrying the tab to load
  * @param onOpenDrawer Callback when hamburger menu is clicked to open drawer
  * @param onTabSelected Callback when a filter tab is selected
  * @param onAddBookmark Callback when FAB is clicked to add a bookmark
@@ -73,26 +73,25 @@ private val sharedEncoder = Nip19EventEncoder()
  * @param onLongPressBookmark Callback notified with rawJson when "Copy raw JSON" is selected
  * @param onCopyNostrLink Callback notified with the encoded nostr:naddr1 URI when "Copy nostr link"
  *   is selected
- * @param onLoadMore Callback when user scrolls near the end of the list to load older bookmarks
+ * @param onLoadMore Callback when user scrolls near the end of the list, carrying the tab to
+ *   paginate
  * @param isReadOnly Whether to hide write-only UI (FAB) for read-only login
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BookmarkScreen(
     uiState: BookmarkUiState,
-    onRefresh: () -> Unit,
-    onLoad: () -> Unit,
+    onRefresh: (BookmarkFilterMode) -> Unit,
+    onLoad: (BookmarkFilterMode) -> Unit,
     onOpenDrawer: () -> Unit = {},
     onTabSelected: (BookmarkFilterMode) -> Unit = {},
     onAddBookmark: () -> Unit = {},
     onBookmarkDetailNavigate: (BookmarkItem) -> Unit = {},
     onLongPressBookmark: (String) -> Unit = {},
     onCopyNostrLink: (String) -> Unit = {},
-    onLoadMore: () -> Unit = {},
+    onLoadMore: (BookmarkFilterMode) -> Unit = {},
     isReadOnly: Boolean = false,
 ) {
-  LaunchedEffect(Unit) { onLoad() }
-
   val clipboardManager = LocalClipboardManager.current
   val hapticFeedback = LocalHapticFeedback.current
 
@@ -144,6 +143,7 @@ fun BookmarkScreen(
         BookmarkPager(
             uiState = uiState,
             onTabSelected = onTabSelected,
+            onLoad = onLoad,
             callbacks = callbacks,
             modifier = Modifier.padding(paddingValues).fillMaxSize())
       }
@@ -153,6 +153,7 @@ fun BookmarkScreen(
 private fun BookmarkPager(
     uiState: BookmarkUiState,
     onTabSelected: (BookmarkFilterMode) -> Unit,
+    onLoad: (BookmarkFilterMode) -> Unit,
     callbacks: BookmarkListCallbacks,
     modifier: Modifier = Modifier,
 ) {
@@ -170,26 +171,22 @@ private fun BookmarkPager(
 
   LaunchedEffect(pagerState) {
     snapshotFlow { pagerState.settledPage }
-        .collect { page -> onTabSelected(BookmarkFilterMode.entries[page]) }
+        .collect { page ->
+          val mode = BookmarkFilterMode.entries[page]
+          onTabSelected(mode)
+          onLoad(mode)
+        }
   }
 
   HorizontalPager(
       state = pagerState,
       modifier = modifier,
   ) { page ->
-    val filteredBookmarks =
-        remember(page, uiState.allBookmarks, uiState.userHexPubkey) {
-          when (BookmarkFilterMode.entries[page]) {
-            BookmarkFilterMode.Local ->
-                uiState.userHexPubkey?.let { hexPubkey ->
-                  uiState.allBookmarks.filter { it.event?.author == hexPubkey }
-                } ?: emptyList()
-            BookmarkFilterMode.Global -> uiState.allBookmarks
-          }
-        }
+    val mode = BookmarkFilterMode.entries[page]
     BookmarkContent(
-        uiState = uiState,
-        bookmarks = filteredBookmarks,
+        mode = mode,
+        tab = uiState.tab(mode),
+        displayMode = uiState.displayMode,
         callbacks = callbacks,
         modifier = Modifier.fillMaxSize())
   }
@@ -228,30 +225,33 @@ private fun BookmarkTopBar(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BookmarkContent(
-    uiState: BookmarkUiState,
-    bookmarks: List<BookmarkItem>,
+    mode: BookmarkFilterMode,
+    tab: BookmarkTabState,
+    displayMode: BookmarkDisplayMode,
     callbacks: BookmarkListCallbacks,
     modifier: Modifier = Modifier,
 ) {
   PullToRefreshBox(
-      isRefreshing = uiState.isLoading, onRefresh = callbacks.onRefresh, modifier = modifier) {
+      isRefreshing = tab.isLoading,
+      onRefresh = { callbacks.onRefresh(mode) },
+      modifier = modifier) {
         when {
-          uiState.isLoading && bookmarks.isEmpty() -> {
+          tab.isLoading && tab.items.isEmpty() -> {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
               CircularProgressIndicator()
             }
           }
-          uiState.error != null && bookmarks.isEmpty() -> {
+          tab.error != null && tab.items.isEmpty() -> {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
               Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
-                    text = uiState.error,
+                    text = tab.error,
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.error)
               }
             }
           }
-          bookmarks.isEmpty() -> {
+          tab.items.isEmpty() -> {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
               Text(
                   text = stringResource(R.string.message_no_bookmarks),
@@ -259,16 +259,18 @@ private fun BookmarkContent(
             }
           }
           else -> {
-            when (uiState.displayMode) {
+            when (displayMode) {
               BookmarkDisplayMode.List ->
                   BookmarkListView(
-                      bookmarks = bookmarks,
-                      isLoadingMore = uiState.isLoadingMore,
+                      mode = mode,
+                      bookmarks = tab.items,
+                      isLoadingMore = tab.isLoadingMore,
                       callbacks = callbacks)
               BookmarkDisplayMode.Grid ->
                   BookmarkGridView(
-                      bookmarks = bookmarks,
-                      isLoadingMore = uiState.isLoadingMore,
+                      mode = mode,
+                      bookmarks = tab.items,
+                      isLoadingMore = tab.isLoadingMore,
                       callbacks = callbacks)
             }
           }
@@ -278,6 +280,7 @@ private fun BookmarkContent(
 
 @Composable
 private fun BookmarkListView(
+    mode: BookmarkFilterMode,
     bookmarks: List<BookmarkItem>,
     isLoadingMore: Boolean,
     callbacks: BookmarkListCallbacks,
@@ -291,7 +294,7 @@ private fun BookmarkListView(
           } ?: false
         }
         .distinctUntilChanged()
-        .collect { nearEnd -> if (nearEnd) callbacks.onLoadMore() }
+        .collect { nearEnd -> if (nearEnd) callbacks.onLoadMore(mode) }
   }
 
   LazyColumn(
@@ -320,6 +323,7 @@ private fun BookmarkListView(
 
 @Composable
 private fun BookmarkGridView(
+    mode: BookmarkFilterMode,
     bookmarks: List<BookmarkItem>,
     isLoadingMore: Boolean,
     callbacks: BookmarkListCallbacks,
@@ -333,7 +337,7 @@ private fun BookmarkGridView(
           } ?: false
         }
         .distinctUntilChanged()
-        .collect { nearEnd -> if (nearEnd) callbacks.onLoadMore() }
+        .collect { nearEnd -> if (nearEnd) callbacks.onLoadMore(mode) }
   }
 
   LazyVerticalStaggeredGrid(
@@ -365,13 +369,19 @@ private fun BookmarkGridView(
 @Preview(showBackground = true)
 @Composable
 private fun BookmarkScreenLoadingPreview() {
-  BookmarkScreen(uiState = BookmarkUiState(isLoading = true), onRefresh = {}, onLoad = {})
+  BookmarkScreen(
+      uiState = BookmarkUiState(local = BookmarkTabState(isLoading = true)),
+      onRefresh = {},
+      onLoad = {})
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun BookmarkScreenEmptyPreview() {
-  BookmarkScreen(uiState = BookmarkUiState(isLoading = false), onRefresh = {}, onLoad = {})
+  BookmarkScreen(
+      uiState = BookmarkUiState(local = BookmarkTabState(isLoaded = true)),
+      onRefresh = {},
+      onLoad = {})
 }
 
 @Preview(showBackground = true)
@@ -409,8 +419,7 @@ private fun BookmarkScreenWithDataPreview() {
   BookmarkScreen(
       uiState =
           BookmarkUiState(
-              isLoading = false,
-              allBookmarks = sampleBookmarks,
+              global = BookmarkTabState(items = sampleBookmarks, isLoaded = true),
               selectedTab = BookmarkFilterMode.Global),
       onRefresh = {},
       onLoad = {})

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkUiState.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkUiState.kt
@@ -4,28 +4,50 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkDisplayMo
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 
 /**
+ * Loading and data state for a single bookmark tab (Local or Global)
+ *
+ * Each tab owns an independent query and pagination cursor so that the author-constrained Local
+ * query and the unconstrained Global query never share state.
+ *
+ * @property items Bookmark items fetched for this tab
+ * @property isLoading Whether the first page is currently being loaded
+ * @property isLoadingMore Whether an additional (older) page is currently being fetched
+ * @property hasMoreItems Whether the relay may still have older items to fetch
+ * @property isLoaded Whether the first page has completed at least once, used to distinguish a
+ *   never-loaded tab from a loaded-but-empty tab for lazy loading
+ * @property error Error message if loading failed
+ */
+data class BookmarkTabState(
+    val items: List<BookmarkItem> = emptyList(),
+    val isLoading: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val hasMoreItems: Boolean = true,
+    val isLoaded: Boolean = false,
+    val error: String? = null,
+)
+
+/**
  * UI state for bookmark list screen
  *
- * @property isLoading Whether bookmark data is currently being loaded
- * @property allBookmarks Complete list of all bookmark items from relay (shared data pool)
- * @property error Error message if loading failed
+ * @property local State for the author-constrained Local tab
+ * @property global State for the unconstrained Global tab
  * @property selectedBookmarkForUrlDialog Bookmark item for which URL selection dialog is shown
  * @property urlOpenError Error message when URL opening fails
  * @property selectedTab Currently selected filter tab (Local or Global)
- * @property userHexPubkey Hex-encoded pubkey of logged-in user for local filtering
  * @property displayMode Current display mode for bookmark list (List or Grid)
- * @property isLoadingMore Whether additional older bookmarks are being fetched
- * @property hasMoreItems Whether more bookmarks may be available from relays
  */
 data class BookmarkUiState(
-    val isLoading: Boolean = false,
-    val allBookmarks: List<BookmarkItem> = emptyList(),
-    val error: String? = null,
+    val local: BookmarkTabState = BookmarkTabState(),
+    val global: BookmarkTabState = BookmarkTabState(),
     val selectedBookmarkForUrlDialog: BookmarkItem? = null,
     val urlOpenError: String? = null,
     val selectedTab: BookmarkFilterMode = BookmarkFilterMode.Local,
-    val userHexPubkey: String? = null,
     val displayMode: BookmarkDisplayMode = BookmarkDisplayMode.List,
-    val isLoadingMore: Boolean = false,
-    val hasMoreItems: Boolean = true,
-)
+) {
+  /** Returns the [BookmarkTabState] backing the given [mode]. */
+  fun tab(mode: BookmarkFilterMode): BookmarkTabState =
+      when (mode) {
+        BookmarkFilterMode.Local -> local
+        BookmarkFilterMode.Global -> global
+      }
+}

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkUiState.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkUiState.kt
@@ -13,8 +13,6 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
  * @property isLoading Whether the first page is currently being loaded
  * @property isLoadingMore Whether an additional (older) page is currently being fetched
  * @property hasMoreItems Whether the relay may still have older items to fetch
- * @property isLoaded Whether the first page has completed at least once, used to distinguish a
- *   never-loaded tab from a loaded-but-empty tab for lazy loading
  * @property error Error message if loading failed
  */
 data class BookmarkTabState(
@@ -22,7 +20,6 @@ data class BookmarkTabState(
     val isLoading: Boolean = false,
     val isLoadingMore: Boolean = false,
     val hasMoreItems: Boolean = true,
-    val isLoaded: Boolean = false,
     val error: String? = null,
 )
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkUiState.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkUiState.kt
@@ -13,6 +13,9 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
  * @property isLoading Whether the first page is currently being loaded
  * @property isLoadingMore Whether an additional (older) page is currently being fetched
  * @property hasMoreItems Whether the relay may still have older items to fetch
+ * @property isLoaded Whether a first-page load has completed at least once. Used only to tell a
+ *   never-loaded tab (show a spinner) apart from a loaded-but-empty one (show "no bookmarks"); it
+ *   does not gate reloading, so a transient failure still recovers on the next visit.
  * @property error Error message if loading failed
  */
 data class BookmarkTabState(
@@ -20,6 +23,7 @@ data class BookmarkTabState(
     val isLoading: Boolean = false,
     val isLoadingMore: Boolean = false,
     val hasMoreItems: Boolean = true,
+    val isLoaded: Boolean = false,
     val error: String? = null,
 )
 

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
@@ -52,63 +52,53 @@ constructor(
   /**
    * Load the first page for [mode]
    *
-   * By default this is a lazy, idempotent load: it does nothing when the tab is already loading or
-   * has completed a load, so it is safe to call every time the tab becomes visible. Pass
-   * [forceReload] to bypass that guard for an explicit pull-to-refresh.
+   * By default this is a lazy load: a tab that already holds items is not refetched, so it is safe
+   * to call every time the tab becomes visible. An empty tab is (re)loaded on every visit so a
+   * transient failure — including a relay timeout that the pool reports as an empty success —
+   * recovers on the next visit instead of sticking on an empty feed. Pass [forceReload] to reload
+   * unconditionally for an explicit pull-to-refresh.
    *
    * @param mode The tab to load (Local queries the current user, Global queries all authors)
-   * @param forceReload When true, reload even if the tab has already been loaded
+   * @param forceReload When true, reload even if the tab already holds items
    */
   fun loadTab(mode: BookmarkFilterMode, forceReload: Boolean = false) {
     val tab = _uiState.value.tab(mode)
-    if (!forceReload && (tab.isLoading || tab.isLoaded)) return
+    if (!forceReload && (tab.isLoading || tab.items.isNotEmpty())) return
     viewModelScope.launch { performLoad(mode) }
   }
 
   private suspend fun performLoad(mode: BookmarkFilterMode) {
     _uiState.updateTab(mode) { it.copy(isLoading = true, error = null) }
 
-    val authorPubkey =
-        when (mode) {
-          BookmarkFilterMode.Global -> null
-          BookmarkFilterMode.Local ->
-              (getLoginStateUseCase()
-                      ?: run {
-                        _uiState.updateTab(mode) {
-                          it.copy(
-                              isLoading = false,
-                              isLoaded = true,
-                              items = emptyList(),
-                              error = "Not logged in")
-                        }
-                        return
-                      })
-                  .pubkey
-                  .npub
-        }
+    val author =
+        resolveAuthorQuery(mode, getLoginStateUseCase)
+            ?: run {
+              _uiState.updateTab(mode) {
+                it.copy(isLoading = false, items = emptyList(), error = "Not logged in")
+              }
+              return
+            }
 
-    val result = getBookmarkListUseCase(authorPubkey, until = null)
-    result.fold(
-        onSuccess = { bookmarkList ->
-          _uiState.updateTab(mode) {
-            it.copy(
-                isLoading = false,
-                isLoadingMore = false,
-                isLoaded = true,
-                items = bookmarkList?.items ?: emptyList(),
-                hasMoreItems = bookmarkList?.hasMore ?: false,
-                error = null)
-          }
-        },
-        onFailure = { e ->
-          _uiState.updateTab(mode) {
-            it.copy(
-                isLoading = false,
-                isLoadingMore = false,
-                isLoaded = true,
-                error = e.message ?: "Failed to load bookmarks")
-          }
-        })
+    getBookmarkListUseCase(author.npub, until = null)
+        .fold(
+            onSuccess = { bookmarkList ->
+              _uiState.updateTab(mode) {
+                it.copy(
+                    isLoading = false,
+                    isLoadingMore = false,
+                    items = bookmarkList?.items ?: emptyList(),
+                    hasMoreItems = bookmarkList?.hasMore ?: false,
+                    error = null)
+              }
+            },
+            onFailure = { e ->
+              _uiState.updateTab(mode) {
+                it.copy(
+                    isLoading = false,
+                    isLoadingMore = false,
+                    error = e.message ?: "Failed to load bookmarks")
+              }
+            })
   }
 
   /**
@@ -160,8 +150,9 @@ constructor(
    * Load older bookmarks for infinite scroll pagination on [mode]
    *
    * Uses the oldest fetched bookmark's createdAt as the `until` cursor (inclusive per NIP-01) to
-   * fetch the next page. Appends new items to the tab and deduplicates by eventId. Stops paginating
-   * when a page yields no new items so that duplicate boundary events cannot cause a runaway load.
+   * fetch the next page. Appends new items to the tab and deduplicates by eventId. The
+   * relay-reported [io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkList.hasMore]
+   * hint drives whether more pages are requested.
    *
    * @param mode The tab to paginate
    */
@@ -177,35 +168,46 @@ constructor(
   private suspend fun performLoadMore(mode: BookmarkFilterMode, oldestCreatedAt: Long) {
     _uiState.updateTab(mode) { it.copy(isLoadingMore = true) }
 
-    val authorPubkey =
-        when (mode) {
-          BookmarkFilterMode.Global -> null
-          BookmarkFilterMode.Local ->
-              (getLoginStateUseCase()
-                      ?: run {
-                        _uiState.updateTab(mode) { it.copy(isLoadingMore = false) }
-                        return
-                      })
-                  .pubkey
-                  .npub
-        }
+    val author =
+        resolveAuthorQuery(mode, getLoginStateUseCase)
+            ?: run {
+              _uiState.updateTab(mode) { it.copy(isLoadingMore = false, hasMoreItems = false) }
+              return
+            }
 
-    val result = getBookmarkListUseCase(authorPubkey, until = oldestCreatedAt)
-    result.fold(
-        onSuccess = { bookmarkList ->
-          val newItems = bookmarkList?.items ?: emptyList()
-          _uiState.updateTab(mode) { current ->
-            val existingIds = current.items.mapNotNull { it.eventId }.toSet()
-            val uniqueNewItems = newItems.filter { it.eventId !in existingIds }
-            current.copy(
-                isLoadingMore = false,
-                items = current.items + uniqueNewItems,
-                hasMoreItems = uniqueNewItems.isNotEmpty() && bookmarkList?.hasMore ?: false)
-          }
-        },
-        onFailure = { _uiState.updateTab(mode) { it.copy(isLoadingMore = false) } })
+    getBookmarkListUseCase(author.npub, until = oldestCreatedAt)
+        .fold(
+            onSuccess = { bookmarkList ->
+              val newItems = bookmarkList?.items ?: emptyList()
+              _uiState.updateTab(mode) { current ->
+                val existingIds = current.items.mapNotNull { it.eventId }.toSet()
+                val uniqueNewItems = newItems.filter { it.eventId !in existingIds }
+                current.copy(
+                    isLoadingMore = false,
+                    items = current.items + uniqueNewItems,
+                    hasMoreItems = bookmarkList?.hasMore ?: false)
+              }
+            },
+            onFailure = { _uiState.updateTab(mode) { it.copy(isLoadingMore = false) } })
   }
 }
+
+/** The npub used to constrain a tab's relay query; null means all authors (the Global tab). */
+private data class AuthorQuery(val npub: String?)
+
+/**
+ * Resolves the [AuthorQuery] for [mode]: Global spans all authors, Local is constrained to the
+ * logged-in user. Returns null only when a Local load is attempted while logged out, which the
+ * caller surfaces as a "Not logged in" state.
+ */
+private suspend fun resolveAuthorQuery(
+    mode: BookmarkFilterMode,
+    getLoginState: GetLoginStateUseCase,
+): AuthorQuery? =
+    when (mode) {
+      BookmarkFilterMode.Global -> AuthorQuery(npub = null)
+      BookmarkFilterMode.Local -> getLoginState()?.let { AuthorQuery(npub = it.pubkey.npub) }
+    }
 
 /**
  * Applies [transform] to the [BookmarkTabState] identified by [mode], leaving the other tab

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
@@ -63,7 +63,8 @@ constructor(
    */
   fun loadTab(mode: BookmarkFilterMode, forceReload: Boolean = false) {
     val tab = _uiState.value.tab(mode)
-    if (!forceReload && (tab.isLoading || tab.items.isNotEmpty())) return
+    if (tab.isLoading) return
+    if (!forceReload && tab.items.isNotEmpty()) return
     viewModelScope.launch { performLoad(mode) }
   }
 
@@ -74,7 +75,11 @@ constructor(
         resolveAuthorQuery(mode, getLoginStateUseCase)
             ?: run {
               _uiState.updateTab(mode) {
-                it.copy(isLoading = false, items = emptyList(), error = "Not logged in")
+                it.copy(
+                    isLoading = false,
+                    isLoaded = true,
+                    items = emptyList(),
+                    error = "Not logged in")
               }
               return
             }
@@ -86,6 +91,7 @@ constructor(
                 it.copy(
                     isLoading = false,
                     isLoadingMore = false,
+                    isLoaded = true,
                     items = bookmarkList?.items ?: emptyList(),
                     hasMoreItems = bookmarkList?.hasMore ?: false,
                     error = null)
@@ -96,6 +102,7 @@ constructor(
                 it.copy(
                     isLoading = false,
                     isLoadingMore = false,
+                    isLoaded = true,
                     error = e.message ?: "Failed to load bookmarks")
               }
             })

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.omochice.pinosu.feature.auth.domain.usecase.GetLoginStateUseCase
-import io.github.omochice.pinosu.feature.bookmark.data.repository.RelayBookmarkRepository.Companion.PAGE_SIZE
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkItem
 import io.github.omochice.pinosu.feature.bookmark.domain.usecase.GetBookmarkListUseCase
 import io.github.omochice.pinosu.feature.settings.domain.usecase.ObserveDisplayModeUseCase
@@ -51,49 +50,64 @@ constructor(
   }
 
   /**
-   * Load bookmarks for the current logged-in user
+   * Load the first page for [mode]
    *
-   * Fetches all bookmarks from relays and stores them in allBookmarks. Filtering is handled by the
-   * Composable layer (BookmarkPager).
+   * By default this is a lazy, idempotent load: it does nothing when the tab is already loading or
+   * has completed a load, so it is safe to call every time the tab becomes visible. Pass
+   * [forceReload] to bypass that guard for an explicit pull-to-refresh.
+   *
+   * @param mode The tab to load (Local queries the current user, Global queries all authors)
+   * @param forceReload When true, reload even if the tab has already been loaded
    */
-  fun loadBookmarks() {
-    viewModelScope.launch { performLoadBookmarks() }
+  fun loadTab(mode: BookmarkFilterMode, forceReload: Boolean = false) {
+    val tab = _uiState.value.tab(mode)
+    if (!forceReload && (tab.isLoading || tab.isLoaded)) return
+    viewModelScope.launch { performLoad(mode) }
   }
 
-  private suspend fun performLoadBookmarks() {
-    _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+  private suspend fun performLoad(mode: BookmarkFilterMode) {
+    _uiState.updateTab(mode) { it.copy(isLoading = true, error = null) }
 
-    val user =
-        getLoginStateUseCase()
-            ?: run {
-              _uiState.value =
-                  _uiState.value.copy(
-                      isLoading = false, error = "Not logged in", allBookmarks = emptyList())
-              return
-            }
+    val authorPubkey =
+        when (mode) {
+          BookmarkFilterMode.Global -> null
+          BookmarkFilterMode.Local ->
+              (getLoginStateUseCase()
+                      ?: run {
+                        _uiState.updateTab(mode) {
+                          it.copy(
+                              isLoading = false,
+                              isLoaded = true,
+                              items = emptyList(),
+                              error = "Not logged in")
+                        }
+                        return
+                      })
+                  .pubkey
+                  .npub
+        }
 
-    val userHexPubkey = user.pubkey.hex
-
-    val result = getBookmarkListUseCase(user.pubkey.npub, until = null)
+    val result = getBookmarkListUseCase(authorPubkey, until = null)
     result.fold(
         onSuccess = { bookmarkList ->
-          val allItems = bookmarkList?.items ?: emptyList()
-          _uiState.update { state ->
-            state.copy(
+          _uiState.updateTab(mode) {
+            it.copy(
                 isLoading = false,
                 isLoadingMore = false,
-                allBookmarks = allItems,
-                userHexPubkey = userHexPubkey,
-                hasMoreItems = allItems.size >= PAGE_SIZE,
+                isLoaded = true,
+                items = bookmarkList?.items ?: emptyList(),
+                hasMoreItems = bookmarkList?.hasMore ?: false,
                 error = null)
           }
         },
         onFailure = { e ->
-          _uiState.value =
-              _uiState.value.copy(
-                  isLoading = false,
-                  isLoadingMore = false,
-                  error = e.message ?: "Failed to load bookmarks")
+          _uiState.updateTab(mode) {
+            it.copy(
+                isLoading = false,
+                isLoadingMore = false,
+                isLoaded = true,
+                error = e.message ?: "Failed to load bookmarks")
+          }
         })
   }
 
@@ -143,44 +157,69 @@ constructor(
   }
 
   /**
-   * Load older bookmarks for infinite scroll pagination
+   * Load older bookmarks for infinite scroll pagination on [mode]
    *
-   * Uses the oldest bookmark's createdAt as the `until` cursor to fetch the next page. Appends new
-   * items to the existing list and deduplicates by eventId.
+   * Uses the oldest fetched bookmark's createdAt as the `until` cursor (inclusive per NIP-01) to
+   * fetch the next page. Appends new items to the tab and deduplicates by eventId. Stops paginating
+   * when a page yields no new items so that duplicate boundary events cannot cause a runaway load.
+   *
+   * @param mode The tab to paginate
    */
-  fun loadMore() {
-    val currentState = _uiState.value
-    if (currentState.isLoadingMore || !currentState.hasMoreItems) return
+  fun loadMore(mode: BookmarkFilterMode) {
+    val tab = _uiState.value.tab(mode)
+    if (tab.isLoadingMore || !tab.hasMoreItems) return
 
-    val oldestCreatedAt =
-        currentState.allBookmarks.mapNotNull { it.event?.createdAt }.minOrNull() ?: return
+    val oldestCreatedAt = tab.items.mapNotNull { it.event?.createdAt }.minOrNull() ?: return
 
-    viewModelScope.launch { performLoadMore(oldestCreatedAt) }
+    viewModelScope.launch { performLoadMore(mode, oldestCreatedAt) }
   }
 
-  private suspend fun performLoadMore(oldestCreatedAt: Long) {
-    _uiState.update { it.copy(isLoadingMore = true) }
+  private suspend fun performLoadMore(mode: BookmarkFilterMode, oldestCreatedAt: Long) {
+    _uiState.updateTab(mode) { it.copy(isLoadingMore = true) }
 
-    val user =
-        getLoginStateUseCase()
-            ?: run {
-              _uiState.update { it.copy(isLoadingMore = false) }
-              return
-            }
+    val authorPubkey =
+        when (mode) {
+          BookmarkFilterMode.Global -> null
+          BookmarkFilterMode.Local ->
+              (getLoginStateUseCase()
+                      ?: run {
+                        _uiState.updateTab(mode) { it.copy(isLoadingMore = false) }
+                        return
+                      })
+                  .pubkey
+                  .npub
+        }
 
-    val result = getBookmarkListUseCase(user.pubkey.npub, until = oldestCreatedAt - 1)
+    val result = getBookmarkListUseCase(authorPubkey, until = oldestCreatedAt)
     result.fold(
         onSuccess = { bookmarkList ->
           val newItems = bookmarkList?.items ?: emptyList()
-          _uiState.update { state ->
-            val existingIds = state.allBookmarks.mapNotNull { it.eventId }.toSet()
+          _uiState.updateTab(mode) { current ->
+            val existingIds = current.items.mapNotNull { it.eventId }.toSet()
             val uniqueNewItems = newItems.filter { it.eventId !in existingIds }
-            state.copy(
+            current.copy(
                 isLoadingMore = false,
-                allBookmarks = state.allBookmarks + uniqueNewItems,
-                hasMoreItems = newItems.size >= PAGE_SIZE)
+                items = current.items + uniqueNewItems,
+                hasMoreItems = uniqueNewItems.isNotEmpty() && bookmarkList?.hasMore ?: false)
           }
         },
-        onFailure = { _uiState.update { it.copy(isLoadingMore = false) } })
+        onFailure = { _uiState.updateTab(mode) { it.copy(isLoadingMore = false) } })
+  }
+}
+
+/**
+ * Applies [transform] to the [BookmarkTabState] identified by [mode], leaving the other tab
+ * untouched. Kept as a top-level helper so the ViewModel's state-mutation logic lives in one place
+ * without inflating the class surface.
+ */
+private fun MutableStateFlow<BookmarkUiState>.updateTab(
+    mode: BookmarkFilterMode,
+    transform: (BookmarkTabState) -> BookmarkTabState,
+) {
+  update { state ->
+    when (mode) {
+      BookmarkFilterMode.Local -> state.copy(local = transform(state.local))
+      BookmarkFilterMode.Global -> state.copy(global = transform(state.global))
+    }
   }
 }

--- a/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepositoryTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepositoryTest.kt
@@ -15,6 +15,7 @@ import io.mockk.mockk
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -218,6 +219,80 @@ class RelayBookmarkRepositoryTest {
 
     coVerify { relayPool.subscribeWithTimeout(any(), match { !it.contains("\"until\"") }, any()) }
   }
+
+  @Test
+  fun `getBookmarkList includes authors constraint when authorPubkey is provided`() = runTest {
+    coEvery { relayListProvider.getRelays() } returns
+        listOf(RelayConfig(url = "wss://relay.example.com"))
+    coEvery { relayPool.subscribeWithTimeout(any(), any(), any()) } returns emptyList()
+
+    repository.getBookmarkList(TEST_VALID_NPUB)
+
+    coVerify { relayPool.subscribeWithTimeout(any(), match { it.contains("\"authors\"") }, any()) }
+  }
+
+  @Test
+  fun `getBookmarkList omits authors constraint when authorPubkey is null`() = runTest {
+    coEvery { relayListProvider.getRelays() } returns
+        listOf(RelayConfig(url = "wss://relay.example.com"))
+    coEvery { relayPool.subscribeWithTimeout(any(), any(), any()) } returns emptyList()
+
+    repository.getBookmarkList(authorPubkey = null)
+
+    coVerify { relayPool.subscribeWithTimeout(any(), match { !it.contains("\"authors\"") }, any()) }
+  }
+
+  @Test
+  fun `getBookmarkList reports hasMore true when a full page of events is returned`() = runTest {
+    val events =
+        (1..RelayBookmarkRepository.PAGE_SIZE).map { i ->
+          NostrEvent(
+              id = "event$i",
+              pubkey = "pubkey$i",
+              createdAt = 1_700_000_000L - i,
+              kind = NipB0.KIND_BOOKMARK_LIST,
+              tags = listOf(listOf("r", "not-a-valid-url")),
+              content = "",
+              sig = "sig$i")
+        }
+
+    coEvery { relayListProvider.getRelays() } returns
+        listOf(RelayConfig(url = "wss://relay.example.com"))
+    coEvery { relayPool.subscribeWithTimeout(any(), any(), any()) } returns events
+
+    val bookmarkList = repository.getBookmarkList(TEST_VALID_NPUB).getOrNull()
+
+    assertNotNull(bookmarkList, "BookmarkList should not be null")
+    assertEquals(0, bookmarkList.items.size, "Events without a usable URL are not displayable")
+    assertTrue(
+        bookmarkList.hasMore,
+        "hasMore should be true based on the raw event count, not the displayable item count")
+  }
+
+  @Test
+  fun `getBookmarkList reports hasMore false when fewer than a page of events is returned`() =
+      runTest {
+        val event =
+            NostrEvent(
+                id = "eventFew",
+                pubkey = "pubkeyFew",
+                createdAt = 1_700_000_000L,
+                kind = NipB0.KIND_BOOKMARK_LIST,
+                tags = listOf(listOf("d", "example.com/few"), listOf("title", "Few")),
+                content = "",
+                sig = "sigFew")
+
+        coEvery { relayListProvider.getRelays() } returns
+            listOf(RelayConfig(url = "wss://relay.example.com"))
+        coEvery { relayPool.subscribeWithTimeout(any(), any(), any()) } returns listOf(event)
+        coEvery { urlMetadataFetcher.fetchMetadata(any()) } returns
+            Result.success(UrlMetadata(title = "Few Title", imageUrl = null))
+
+        val bookmarkList = repository.getBookmarkList(TEST_VALID_NPUB).getOrNull()
+
+        assertNotNull(bookmarkList, "BookmarkList should not be null")
+        assertFalse(bookmarkList.hasMore, "hasMore should be false for a partial page")
+      }
 
   @Test
   fun `createBookmarkEvent includes client tag when clientTagEnabled is true`() {

--- a/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModelTest.kt
@@ -270,7 +270,22 @@ class BookmarkViewModelTest {
   }
 
   @Test
-  fun `loadTab is idempotent and does not refetch an already loaded tab`() = runTest {
+  fun `loadTab does not refetch a tab that already holds items`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } returns
+        Result.success(BookmarkList("test", listOf(bookmark("id1", 1_700_000_000L)), 0L))
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    coVerify(exactly = 1) { getBookmarkListUseCase(any(), any()) }
+  }
+
+  @Test
+  fun `loadTab reloads an empty tab so a transient failure can recover`() = runTest {
     val testUser = User(Pubkey.parse(testNpub)!!)
     coEvery { getLoginStateUseCase() } returns testUser
     coEvery { getBookmarkListUseCase(any(), any()) } returns
@@ -281,7 +296,7 @@ class BookmarkViewModelTest {
     viewModel.loadTab(BookmarkFilterMode.Local)
     advanceUntilIdle()
 
-    coVerify(exactly = 1) { getBookmarkListUseCase(any(), any()) }
+    coVerify(exactly = 2) { getBookmarkListUseCase(any(), any()) }
   }
 
   @Test
@@ -432,6 +447,59 @@ class BookmarkViewModelTest {
 
     val state = viewModel.uiState.first()
     assertFalse(state.local.hasMoreItems, "hasMoreItems should be false when relay has no more")
+  }
+
+  @Test
+  fun `loadMore keeps hasMoreItems when a page is all duplicates but relay reports more`() =
+      runTest {
+        val testUser = User(Pubkey.parse(testNpub)!!)
+        val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L) }
+
+        coEvery { getLoginStateUseCase() } returns testUser
+        coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
+            {
+              // Both pages return the same boundary events (shared oldest timestamp, inclusive
+              // until). hasMore stays true, so pagination must not be stopped just because the page
+              // added no new unique items.
+              Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
+            }
+
+        viewModel.loadTab(BookmarkFilterMode.Local)
+        advanceUntilIdle()
+
+        viewModel.loadMore(BookmarkFilterMode.Local)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.first()
+        assertEquals(10, state.local.items.size, "duplicates should not be appended")
+        assertTrue(
+            state.local.hasMoreItems,
+            "hasMoreItems should follow the relay hint, not the unique-item count",
+        )
+      }
+
+  @Test
+  fun `loadMore stops pagination when logged out mid-session`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L - i * 100) }
+
+    coEvery { getBookmarkListUseCase(any(), any()) } returns
+        Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
+    coEvery { getLoginStateUseCase() } returns testUser
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    coEvery { getLoginStateUseCase() } returns null
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    val state = viewModel.uiState.first()
+    assertFalse(state.local.isLoadingMore, "isLoadingMore should be reset")
+    assertFalse(
+        state.local.hasMoreItems,
+        "hasMoreItems should be cleared so no-op pagination coroutines stop relaunching",
+    )
   }
 
   @Test

--- a/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModelTest.kt
@@ -13,6 +13,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -33,11 +34,12 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 
 /**
- * Unit tests for BookmarkViewModel URL click functionality
+ * Unit tests for [BookmarkViewModel]
  *
  * Tests cover:
- * - Multiple URLs dialog state management
- * - Error dialog state management
+ * - Per-tab lazy loading and refresh (Local queries the current user, Global queries all authors)
+ * - Per-tab pagination with an inclusive cursor and hasMore-driven termination
+ * - Multiple URLs dialog and error dialog state management
  * - Display mode observation
  */
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -50,6 +52,8 @@ class BookmarkViewModelTest {
   private lateinit var viewModel: BookmarkViewModel
 
   private val testDispatcher = StandardTestDispatcher()
+
+  private val testNpub = "npub1" + "a".repeat(58)
 
   @BeforeTest
   fun setup() {
@@ -68,12 +72,22 @@ class BookmarkViewModelTest {
     Dispatchers.resetMain()
   }
 
+  private fun bookmark(id: String, createdAt: Long): BookmarkItem =
+      BookmarkItem(
+          type = "event",
+          eventId = id,
+          title = "Bookmark $id",
+          event =
+              BookmarkedEvent(
+                  kind = 39_701, content = "", author = "author", createdAt = createdAt))
+
   @Test
   fun `initial BookmarkUiState should have default values`() = runTest {
     val state = viewModel.uiState.first()
 
-    assertFalse(state.isLoading, "isLoading should be false")
-    assertNull(state.error, "error should be null")
+    assertFalse(state.local.isLoading, "local isLoading should be false")
+    assertFalse(state.global.isLoading, "global isLoading should be false")
+    assertNull(state.local.error, "local error should be null")
     assertNull(state.selectedBookmarkForUrlDialog, "selectedBookmarkForUrlDialog should be null")
     assertNull(state.urlOpenError, "urlOpenError should be null")
   }
@@ -169,121 +183,287 @@ class BookmarkViewModelTest {
   }
 
   @Test
-  fun `loadBookmarks should set isLoading to true initially`() = runTest {
-    val testUser = User(Pubkey.parse("npub1" + "a".repeat(58))!!)
+  fun `loadTab Local should set isLoading to true initially`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
     coEvery { getLoginStateUseCase() } returns testUser
-    coEvery { getBookmarkListUseCase(any()) } coAnswers
+    coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
         {
           kotlinx.coroutines.delay(100)
           Result.success(BookmarkList("test", emptyList(), 0L))
         }
 
-    viewModel.loadBookmarks()
+    viewModel.loadTab(BookmarkFilterMode.Local)
     testScheduler.runCurrent()
 
     val state = viewModel.uiState.first()
-    assertTrue(state.isLoading, "isLoading should be true during loading")
+    assertTrue(state.local.isLoading, "local isLoading should be true during loading")
   }
 
   @Test
-  fun `loadBookmarks should store bookmarks in allBookmarks`() = runTest {
-    val testUser = User(Pubkey.parse("npub1" + "a".repeat(58))!!)
-    val testBookmarks =
-        listOf(
-            BookmarkItem(
-                type = "event",
-                eventId = "id1",
-                title = "Bookmark 1",
-                urls = listOf("https://example.com/1")))
-    val bookmarkList = BookmarkList("test", testBookmarks, 0L)
-
+  fun `loadTab Local should store bookmarks in the local tab`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val testBookmarks = listOf(bookmark("id1", 1_700_000_000L))
     coEvery { getLoginStateUseCase() } returns testUser
-    coEvery { getBookmarkListUseCase(any()) } returns Result.success(bookmarkList)
+    coEvery { getBookmarkListUseCase(any(), any()) } returns
+        Result.success(BookmarkList("test", testBookmarks, 0L))
 
-    viewModel.loadBookmarks()
+    viewModel.loadTab(BookmarkFilterMode.Local)
     advanceUntilIdle()
 
     val state = viewModel.uiState.first()
-    assertFalse(state.isLoading, "isLoading should be false after loading")
-    assertEquals(testBookmarks, state.allBookmarks, "allBookmarks should be set")
-    assertNull(state.error, "error should be null on success")
+    assertFalse(state.local.isLoading, "local isLoading should be false after loading")
+    assertEquals(testBookmarks, state.local.items, "local items should be set")
+    assertNull(state.local.error, "local error should be null on success")
   }
 
   @Test
-  fun `loadBookmarks should set error when not logged in`() = runTest {
-    coEvery { getLoginStateUseCase() } returns null
-
-    viewModel.loadBookmarks()
-    advanceUntilIdle()
-
-    val state = viewModel.uiState.first()
-    assertFalse(state.isLoading, "isLoading should be false")
-    assertEquals("Not logged in", state.error, "error should indicate not logged in")
-  }
-
-  @Test
-  fun `loadBookmarks should set error on failure`() = runTest {
-    val testUser = User(Pubkey.parse("npub1" + "a".repeat(58))!!)
-    val errorMessage = "Network error"
+  fun `loadTab Local should query with the user npub as author`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val authorSlot = slot<String?>()
     coEvery { getLoginStateUseCase() } returns testUser
-    coEvery { getBookmarkListUseCase(any()) } returns Result.failure(Exception(errorMessage))
-
-    viewModel.loadBookmarks()
-    advanceUntilIdle()
-
-    val state = viewModel.uiState.first()
-    assertFalse(state.isLoading, "isLoading should be false")
-    assertEquals(errorMessage, state.error, "error should be set")
-  }
-
-  @Test
-  fun `loadBookmarks should fetch bookmarks from relays`() = runTest {
-    val testUser = User(Pubkey.parse("npub1" + "a".repeat(58))!!)
-    coEvery { getLoginStateUseCase() } returns testUser
-    coEvery { getBookmarkListUseCase(any()) } returns
+    coEvery { getBookmarkListUseCase(captureNullable(authorSlot), any()) } returns
         Result.success(BookmarkList("test", emptyList(), 0L))
 
-    viewModel.loadBookmarks()
+    viewModel.loadTab(BookmarkFilterMode.Local)
     advanceUntilIdle()
 
-    coVerify { getBookmarkListUseCase(any()) }
+    assertEquals(testNpub, authorSlot.captured, "Local tab should query constrained to the user")
   }
 
   @Test
-  fun `multiple URL dialog workflow should work correctly`() = runTest {
-    val bookmark =
-        BookmarkItem(
-            type = "event",
-            eventId = "workflow-test",
-            title = "Workflow Test",
-            urls = listOf("https://example.com/1", "https://example.com/2"))
+  fun `loadTab Global should query with a null author`() = runTest {
+    val authorSlot = slot<String?>()
+    coEvery { getBookmarkListUseCase(captureNullable(authorSlot), any()) } returns
+        Result.success(BookmarkList("test", emptyList(), 0L))
 
-    viewModel.onBookmarkCardClicked(bookmark)
+    viewModel.loadTab(BookmarkFilterMode.Global)
     advanceUntilIdle()
 
-    var state = viewModel.uiState.first()
-    assertNotNull(state.selectedBookmarkForUrlDialog, "Dialog should be shown")
-
-    viewModel.dismissUrlDialog()
-    advanceUntilIdle()
-
-    state = viewModel.uiState.first()
-    assertNull(state.selectedBookmarkForUrlDialog, "Dialog should be dismissed")
+    assertNull(authorSlot.captured, "Global tab should query without an author constraint")
   }
 
   @Test
-  fun `error dialog workflow should work correctly`() = runTest {
-    viewModel.setUrlOpenError("Test error")
+  fun `loadTab Local should set error when not logged in`() = runTest {
+    coEvery { getLoginStateUseCase() } returns null
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
     advanceUntilIdle()
 
-    var state = viewModel.uiState.first()
-    assertNotNull(state.urlOpenError, "Error should be shown")
+    val state = viewModel.uiState.first()
+    assertFalse(state.local.isLoading, "local isLoading should be false")
+    assertEquals("Not logged in", state.local.error, "local error should indicate not logged in")
+  }
 
-    viewModel.dismissErrorDialog()
+  @Test
+  fun `loadTab Local should set error on failure`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val errorMessage = "Network error"
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } returns Result.failure(Exception(errorMessage))
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
     advanceUntilIdle()
 
-    state = viewModel.uiState.first()
-    assertNull(state.urlOpenError, "Error should be dismissed")
+    val state = viewModel.uiState.first()
+    assertFalse(state.local.isLoading, "local isLoading should be false")
+    assertEquals(errorMessage, state.local.error, "local error should be set")
+  }
+
+  @Test
+  fun `loadTab is idempotent and does not refetch an already loaded tab`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } returns
+        Result.success(BookmarkList("test", emptyList(), 0L))
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    coVerify(exactly = 1) { getBookmarkListUseCase(any(), any()) }
+  }
+
+  @Test
+  fun `loadMore appends new items to the local tab`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L - i * 100) }
+    val olderBookmarks = (11..15).map { i -> bookmark("id$i", 1_700_000_000L - i * 100) }
+
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
+        {
+          val until = secondArg<Long?>()
+          if (until == null) {
+            Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
+          } else {
+            Result.success(BookmarkList("test", olderBookmarks, 0L, hasMore = false))
+          }
+        }
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    val state = viewModel.uiState.first()
+    assertEquals(
+        15, state.local.items.size, "local items should contain both initial and older items")
+    assertFalse(state.local.isLoadingMore, "isLoadingMore should be false after loading")
+  }
+
+  @Test
+  fun `loadMore uses an inclusive until cursor equal to the oldest createdAt`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val oldestCreatedAt = 1_700_000_000L - 10 * 100
+    val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L - i * 100) }
+    val untilSlot = slot<Long?>()
+
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), captureNullable(untilSlot)) } coAnswers
+        {
+          val until = secondArg<Long?>()
+          if (until == null) {
+            Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
+          } else {
+            Result.success(BookmarkList("test", emptyList(), 0L, hasMore = false))
+          }
+        }
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    assertEquals(
+        oldestCreatedAt,
+        untilSlot.captured,
+        "until should equal the oldest createdAt (inclusive per NIP-01)")
+  }
+
+  @Test
+  fun `loadMore does nothing when isLoadingMore is true`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L - i * 100) }
+
+    var loadMoreCallCount = 0
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
+        {
+          val until = secondArg<Long?>()
+          if (until == null) {
+            Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
+          } else {
+            loadMoreCallCount++
+            kotlinx.coroutines.delay(1000)
+            Result.success(BookmarkList("test", emptyList(), 0L, hasMore = false))
+          }
+        }
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    testScheduler.runCurrent()
+
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    assertEquals(1, loadMoreCallCount, "loadMore should only trigger one usecase call")
+  }
+
+  @Test
+  fun `loadMore does nothing when hasMoreItems is false`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L - i * 100) }
+
+    var loadMoreCallCount = 0
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
+        {
+          val until = secondArg<Long?>()
+          if (until == null) {
+            Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
+          } else {
+            loadMoreCallCount++
+            Result.success(BookmarkList("test", emptyList(), 0L, hasMore = false))
+          }
+        }
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    assertEquals(
+        1,
+        loadMoreCallCount,
+        "loadMore should only be called once because hasMoreItems becomes false")
+  }
+
+  @Test
+  fun `loadMore sets hasMoreItems to false when relay reports no more items`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L - i * 100) }
+    val fewOlderBookmarks = listOf(bookmark("id11", 1_699_998_000L))
+
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
+        {
+          val until = secondArg<Long?>()
+          if (until == null) {
+            Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
+          } else {
+            Result.success(BookmarkList("test", fewOlderBookmarks, 0L, hasMore = false))
+          }
+        }
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    val state = viewModel.uiState.first()
+    assertFalse(state.local.hasMoreItems, "hasMoreItems should be false when relay has no more")
+  }
+
+  @Test
+  fun `refresh resets hasMoreItems to true`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L - i * 100) }
+
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
+        {
+          val until = secondArg<Long?>()
+          if (until == null) {
+            Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
+          } else {
+            Result.success(BookmarkList("test", emptyList(), 0L, hasMore = false))
+          }
+        }
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    advanceUntilIdle()
+    assertFalse(
+        viewModel.uiState.first().local.hasMoreItems,
+        "hasMoreItems should be false after exhausting")
+
+    viewModel.loadTab(BookmarkFilterMode.Local, forceReload = true)
+    advanceUntilIdle()
+
+    assertTrue(
+        viewModel.uiState.first().local.hasMoreItems, "hasMoreItems should be true after refresh")
   }
 
   @Test
@@ -304,14 +484,14 @@ class BookmarkViewModelTest {
 
   @Test
   fun `state should handle concurrent dialog states independently`() = runTest {
-    val bookmark =
+    val multiUrlBookmark =
         BookmarkItem(
             type = "event",
             eventId = "concurrent-test",
             title = "Concurrent Test",
             urls = listOf("https://example.com/1", "https://example.com/2"))
 
-    viewModel.onBookmarkCardClicked(bookmark)
+    viewModel.onBookmarkCardClicked(multiUrlBookmark)
     viewModel.setUrlOpenError("Test error")
     advanceUntilIdle()
 
@@ -325,238 +505,5 @@ class BookmarkViewModelTest {
     val stateAfterDismissUrl = viewModel.uiState.first()
     assertNull(stateAfterDismissUrl.selectedBookmarkForUrlDialog, "URL dialog should be dismissed")
     assertNotNull(stateAfterDismissUrl.urlOpenError, "Error dialog should still be shown")
-  }
-
-  @Test
-  fun `loadMore appends new items to existing allBookmarks`() = runTest {
-    val testUser = User(Pubkey.parse("npub1" + "a".repeat(58))!!)
-    val initialBookmarks =
-        (1..10).map { i ->
-          BookmarkItem(
-              type = "event",
-              eventId = "id$i",
-              title = "Bookmark $i",
-              event =
-                  BookmarkedEvent(
-                      kind = 39_701,
-                      content = "",
-                      author = "author",
-                      createdAt = 1_700_000_000L - i * 100))
-        }
-    val olderBookmarks =
-        (11..15).map { i ->
-          BookmarkItem(
-              type = "event",
-              eventId = "id$i",
-              title = "Bookmark $i",
-              event =
-                  BookmarkedEvent(
-                      kind = 39_701,
-                      content = "",
-                      author = "author",
-                      createdAt = 1_700_000_000L - i * 100))
-        }
-
-    coEvery { getLoginStateUseCase() } returns testUser
-    coEvery { getBookmarkListUseCase(any(), any<Long>()) } coAnswers
-        {
-          val until = secondArg<Long?>()
-          if (until == null) {
-            Result.success(BookmarkList("test", initialBookmarks, 0L))
-          } else {
-            Result.success(BookmarkList("test", olderBookmarks, 0L))
-          }
-        }
-
-    viewModel.loadBookmarks()
-    advanceUntilIdle()
-
-    viewModel.loadMore()
-    advanceUntilIdle()
-
-    val state = viewModel.uiState.first()
-    assertEquals(
-        15, state.allBookmarks.size, "allBookmarks should contain both initial and older items")
-    assertFalse(state.isLoadingMore, "isLoadingMore should be false after loading")
-  }
-
-  @Test
-  fun `loadMore does nothing when isLoadingMore is true`() = runTest {
-    val testUser = User(Pubkey.parse("npub1" + "a".repeat(58))!!)
-    val initialBookmarks =
-        (1..10).map { i ->
-          BookmarkItem(
-              type = "event",
-              eventId = "id$i",
-              title = "Bookmark $i",
-              event =
-                  BookmarkedEvent(
-                      kind = 39_701,
-                      content = "",
-                      author = "author",
-                      createdAt = 1_700_000_000L - i * 100))
-        }
-
-    var loadMoreCallCount = 0
-    coEvery { getLoginStateUseCase() } returns testUser
-    coEvery { getBookmarkListUseCase(any(), any<Long>()) } coAnswers
-        {
-          val until = secondArg<Long?>()
-          if (until == null) {
-            Result.success(BookmarkList("test", initialBookmarks, 0L))
-          } else {
-            loadMoreCallCount++
-            kotlinx.coroutines.delay(1000)
-            Result.success(BookmarkList("test", emptyList(), 0L))
-          }
-        }
-
-    viewModel.loadBookmarks()
-    advanceUntilIdle()
-
-    viewModel.loadMore()
-    testScheduler.runCurrent()
-
-    viewModel.loadMore()
-    advanceUntilIdle()
-
-    assertEquals(1, loadMoreCallCount, "loadMore should only trigger one usecase call")
-  }
-
-  @Test
-  fun `loadMore does nothing when hasMoreItems is false`() = runTest {
-    val testUser = User(Pubkey.parse("npub1" + "a".repeat(58))!!)
-    val initialBookmarks =
-        (1..10).map { i ->
-          BookmarkItem(
-              type = "event",
-              eventId = "id$i",
-              title = "Bookmark $i",
-              event =
-                  BookmarkedEvent(
-                      kind = 39_701,
-                      content = "",
-                      author = "author",
-                      createdAt = 1_700_000_000L - i * 100))
-        }
-
-    var loadMoreCallCount = 0
-    coEvery { getLoginStateUseCase() } returns testUser
-    coEvery { getBookmarkListUseCase(any(), any<Long>()) } coAnswers
-        {
-          val until = secondArg<Long?>()
-          if (until == null) {
-            Result.success(BookmarkList("test", initialBookmarks, 0L))
-          } else {
-            loadMoreCallCount++
-            Result.success(BookmarkList("test", emptyList(), 0L))
-          }
-        }
-
-    viewModel.loadBookmarks()
-    advanceUntilIdle()
-
-    viewModel.loadMore()
-    advanceUntilIdle()
-
-    viewModel.loadMore()
-    advanceUntilIdle()
-
-    assertEquals(
-        1,
-        loadMoreCallCount,
-        "loadMore should only be called once because hasMoreItems becomes false")
-  }
-
-  @Test
-  fun `loadMore sets hasMoreItems to false when fewer items than page size returned`() = runTest {
-    val testUser = User(Pubkey.parse("npub1" + "a".repeat(58))!!)
-    val initialBookmarks =
-        (1..10).map { i ->
-          BookmarkItem(
-              type = "event",
-              eventId = "id$i",
-              title = "Bookmark $i",
-              event =
-                  BookmarkedEvent(
-                      kind = 39_701,
-                      content = "",
-                      author = "author",
-                      createdAt = 1_700_000_000L - i * 100))
-        }
-    val fewOlderBookmarks =
-        listOf(
-            BookmarkItem(
-                type = "event",
-                eventId = "id11",
-                title = "Bookmark 11",
-                event =
-                    BookmarkedEvent(
-                        kind = 39_701,
-                        content = "",
-                        author = "author",
-                        createdAt = 1_699_998_000L)))
-
-    coEvery { getLoginStateUseCase() } returns testUser
-    coEvery { getBookmarkListUseCase(any(), any<Long>()) } coAnswers
-        {
-          val until = secondArg<Long?>()
-          if (until == null) {
-            Result.success(BookmarkList("test", initialBookmarks, 0L))
-          } else {
-            Result.success(BookmarkList("test", fewOlderBookmarks, 0L))
-          }
-        }
-
-    viewModel.loadBookmarks()
-    advanceUntilIdle()
-
-    viewModel.loadMore()
-    advanceUntilIdle()
-
-    val state = viewModel.uiState.first()
-    assertFalse(state.hasMoreItems, "hasMoreItems should be false when fewer than page size")
-  }
-
-  @Test
-  fun `refresh resets hasMoreItems to true`() = runTest {
-    val testUser = User(Pubkey.parse("npub1" + "a".repeat(58))!!)
-    val initialBookmarks =
-        (1..10).map { i ->
-          BookmarkItem(
-              type = "event",
-              eventId = "id$i",
-              title = "Bookmark $i",
-              event =
-                  BookmarkedEvent(
-                      kind = 39_701,
-                      content = "",
-                      author = "author",
-                      createdAt = 1_700_000_000L - i * 100))
-        }
-
-    coEvery { getLoginStateUseCase() } returns testUser
-    coEvery { getBookmarkListUseCase(any(), any<Long>()) } coAnswers
-        {
-          val until = secondArg<Long?>()
-          if (until == null) {
-            Result.success(BookmarkList("test", initialBookmarks, 0L))
-          } else {
-            Result.success(BookmarkList("test", emptyList(), 0L))
-          }
-        }
-
-    viewModel.loadBookmarks()
-    advanceUntilIdle()
-
-    viewModel.loadMore()
-    advanceUntilIdle()
-    assertFalse(
-        viewModel.uiState.first().hasMoreItems, "hasMoreItems should be false after exhausting")
-
-    viewModel.loadBookmarks()
-    advanceUntilIdle()
-
-    assertTrue(viewModel.uiState.first().hasMoreItems, "hasMoreItems should be true after refresh")
   }
 }

--- a/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModelTest.kt
@@ -300,6 +300,25 @@ class BookmarkViewModelTest {
   }
 
   @Test
+  fun `loadTab ignores a forceReload while a load is already in flight`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
+        {
+          kotlinx.coroutines.delay(1000)
+          Result.success(BookmarkList("test", emptyList(), 0L))
+        }
+
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    testScheduler.runCurrent()
+
+    viewModel.loadTab(BookmarkFilterMode.Local, forceReload = true)
+    advanceUntilIdle()
+
+    coVerify(exactly = 1) { getBookmarkListUseCase(any(), any()) }
+  }
+
+  @Test
   fun `loadMore appends new items to the local tab`() = runTest {
     val testUser = User(Pubkey.parse(testNpub)!!)
     val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L - i * 100) }


### PR DESCRIPTION
## Summary

Reworks the bookmark feature so the Local and Global tabs each own an independent Nostr query and pagination state, fixing four review findings that all stem from both tabs sharing a single unconstrained global query with client-side filtering for Local.

## Structure

Two commits, Tidy First (structural/data-API change first, behavioural presentation fix second):
1. `refactor(bookmark): make bookmark query author-optional and report hasMore`
2. `fix(bookmark): give Local and Global tabs independent bookmarks`

## Testing

- `devbox run ./gradlew detekt test` — green
- `devbox run ./gradlew connectedAndroidTest` (API 34 emulator) — green

https://claude.ai/code/session_01KymzQo19a8H3xq6WPBLyCg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bookmark browsing now supports separate Local and Global tabs, with loading and refresh behavior handled per tab.
  * Infinite scrolling and pull-to-refresh now work more consistently across bookmark views.

* **Bug Fixes**
  * Improved bookmark pagination so more items load correctly and duplicates no longer stop scrolling too early.
  * Bookmark lists now better reflect loading, empty, and error states for each tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->