### PR TITLE
fix: surface corrupt auth data instead of silently resetting it

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/data/local/AuthDataSerializer.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/data/local/AuthDataSerializer.kt
@@ -25,11 +25,9 @@ class AuthDataSerializer(private val aead: Aead) : Serializer<AuthData> {
       return defaultValue
     }
 
-    // Non-empty data that fails to decrypt or deserialize is genuinely corrupt or currently
-    // unreadable (e.g. a rotated Tink keyset or a temporarily inaccessible keystore key). Returning
-    // defaultValue here would be indistinguishable from a fresh install and would silently discard
-    // the still-encrypted data on disk, so surface it as a CorruptionException instead. The file is
-    // left untouched so the data can still be recovered once the key becomes readable again.
+    // Returning defaultValue here would look like a fresh install and silently discard the
+    // still-encrypted data, so surface corruption instead. The file is left intact for recovery
+    // once the key becomes readable again.
     return try {
       val decryptedBytes = aead.decrypt(encryptedBytes, ASSOCIATED_DATA)
       Json.decodeFromString<AuthData>(decryptedBytes.decodeToString())

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/data/local/AuthDataSerializer.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/data/local/AuthDataSerializer.kt
@@ -1,9 +1,12 @@
 package io.github.omochice.pinosu.feature.auth.data.local
 
+import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.Serializer
 import com.google.crypto.tink.Aead
 import java.io.InputStream
 import java.io.OutputStream
+import java.security.GeneralSecurityException
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 
 /**
@@ -22,11 +25,18 @@ class AuthDataSerializer(private val aead: Aead) : Serializer<AuthData> {
       return defaultValue
     }
 
+    // Non-empty data that fails to decrypt or deserialize is genuinely corrupt or currently
+    // unreadable (e.g. a rotated Tink keyset or a temporarily inaccessible keystore key). Returning
+    // defaultValue here would be indistinguishable from a fresh install and would silently discard
+    // the still-encrypted data on disk, so surface it as a CorruptionException instead. The file is
+    // left untouched so the data can still be recovered once the key becomes readable again.
     return try {
       val decryptedBytes = aead.decrypt(encryptedBytes, ASSOCIATED_DATA)
       Json.decodeFromString<AuthData>(decryptedBytes.decodeToString())
-    } catch (_: Exception) {
-      defaultValue
+    } catch (e: GeneralSecurityException) {
+      throw CorruptionException("Failed to decrypt stored auth data", e)
+    } catch (e: SerializationException) {
+      throw CorruptionException("Failed to deserialize stored auth data", e)
     }
   }
 

--- a/app/src/test/java/io/github/omochice/pinosu/feature/auth/data/local/AuthDataSerializerTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/auth/data/local/AuthDataSerializerTest.kt
@@ -91,6 +91,21 @@ class AuthDataSerializerTest {
       }
 
   @Test
+  fun `readFrom with trailing data after valid JSON throws CorruptionException`() = runTest {
+    val authData = AuthData(userPubkey = "abc123", createdAt = 1000L, lastAccessed = 2000L)
+    val validJson = Json.encodeToString(authData)
+    val encryptedBytes = "encrypted_data".toByteArray()
+    val associatedData = "pinosu_auth_data".toByteArray()
+
+    every { mockAead.decrypt(encryptedBytes, associatedData) } returns
+        "$validJson{\"trailing\":true}".toByteArray()
+
+    assertFailsWith<CorruptionException> {
+      serializer.readFrom(ByteArrayInputStream(encryptedBytes))
+    }
+  }
+
+  @Test
   fun `writeTo encrypts data and writes to output stream`() = runTest {
     val authData = AuthData(userPubkey = "test_pubkey", createdAt = 5000L, lastAccessed = 6000L)
     val jsonBytes = Json.encodeToString(authData).encodeToByteArray()

--- a/app/src/test/java/io/github/omochice/pinosu/feature/auth/data/local/AuthDataSerializerTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/auth/data/local/AuthDataSerializerTest.kt
@@ -1,5 +1,6 @@
 package io.github.omochice.pinosu.feature.auth.data.local
 
+import androidx.datastore.core.CorruptionException
 import com.google.crypto.tink.Aead
 import io.github.omochice.pinosu.feature.auth.domain.model.LoginMode
 import io.mockk.every
@@ -12,6 +13,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.runner.RunWith
@@ -62,18 +64,31 @@ class AuthDataSerializerTest {
   }
 
   @Test
-  fun `readFrom when decrypt throws exception returns default value`() = runTest {
+  fun `readFrom when decrypt fails throws CorruptionException instead of default`() = runTest {
     val encryptedBytes = "corrupted_data".toByteArray()
     val associatedData = "pinosu_auth_data".toByteArray()
 
     every { mockAead.decrypt(encryptedBytes, associatedData) } throws
         GeneralSecurityException("Decryption failed")
 
-    val input = ByteArrayInputStream(encryptedBytes)
-    val result = serializer.readFrom(input)
-
-    assertEquals(AuthData.DEFAULT, result)
+    assertFailsWith<CorruptionException> {
+      serializer.readFrom(ByteArrayInputStream(encryptedBytes))
+    }
   }
+
+  @Test
+  fun `readFrom when deserialization fails throws CorruptionException instead of default`() =
+      runTest {
+        val encryptedBytes = "encrypted_data".toByteArray()
+        val associatedData = "pinosu_auth_data".toByteArray()
+
+        every { mockAead.decrypt(encryptedBytes, associatedData) } returns
+            "not-valid-json".toByteArray()
+
+        assertFailsWith<CorruptionException> {
+          serializer.readFrom(ByteArrayInputStream(encryptedBytes))
+        }
+      }
 
   @Test
   fun `writeTo encrypts data and writes to output stream`() = runTest {


### PR DESCRIPTION
## Summary

`AuthDataSerializer.readFrom` now throws `CorruptionException` when stored auth data cannot be decrypted or deserialized, instead of silently returning defaults (review finding 4).

## Details

Catching every exception and returning `defaultValue` made a decryption or deserialization failure on non-empty stored data indistinguishable from a fresh install, silently logging the user out and masking their still-encrypted data.

The file on disk is intentionally left untouched (no `ReplaceFileCorruptionHandler`), so the data can be recovered once the key becomes readable again rather than being overwritten with defaults.

## Confirmation

Ran `devbox run ./gradlew detekt test` locally and confirmed it is green, including a new test asserting that valid JSON followed by trailing bytes is surfaced as corruption.

## Limitation

While the key is unreadable, `updateData` (login and logout) fails until it becomes readable again; distinguishing transient key failures from permanent corruption and adding a recovery handler is left as follow-up.

https://claude.ai/code/session_01C5raaQMqnpDtTRT5APanLT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreadable stored authentication data by surfacing corruption instead of silently falling back to default values.
  * If saved auth data can’t be decrypted or parsed, the app now reports it as corrupted data, helping prevent hidden data loss.
  * Expanded test coverage to verify the new failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

