### PR TITLE
fix: trim trailing punctuation from extracted shared URL

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/ExtractSharedContentUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/ExtractSharedContentUseCaseImpl.kt
@@ -31,7 +31,7 @@ class ExtractSharedContentUseCaseImpl @Inject constructor() : ExtractSharedConte
     return if (urlMatch != null) {
       val urlRange = trimmedUrlRange(text, urlMatch.range)
       val url = text.substring(urlRange)
-      val remaining = text.removeRange(urlRange).trim().replace(Regex("\\s{2,}"), " ")
+      val remaining = text.removeRange(urlRange).trim().replace(MULTIPLE_SPACES_PATTERN, " ")
       SharedContent(url = url, comment = remaining.ifBlank { null })
     } else {
       SharedContent(comment = text)
@@ -40,5 +40,6 @@ class ExtractSharedContentUseCaseImpl @Inject constructor() : ExtractSharedConte
 
   companion object {
     private val URL_PATTERN = """https?://\S+""".toRegex(RegexOption.IGNORE_CASE)
+    private val MULTIPLE_SPACES_PATTERN = Regex("\\s{2,}")
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/ExtractSharedContentUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/ExtractSharedContentUseCaseImpl.kt
@@ -29,15 +29,40 @@ class ExtractSharedContentUseCaseImpl @Inject constructor() : ExtractSharedConte
 
     val urlMatch = URL_PATTERN.find(text)
     return if (urlMatch != null) {
-      val url = urlMatch.value
-      val remaining = text.removeRange(urlMatch.range).trim().replace(Regex("\\s{2,}"), " ")
+      val urlRange = urlMatch.range.first..trailingTrimmedEnd(text, urlMatch.range)
+      val url = text.substring(urlRange)
+      val remaining = text.removeRange(urlRange).trim().replace(Regex("\\s{2,}"), " ")
       SharedContent(url = url, comment = remaining.ifBlank { null })
     } else {
       SharedContent(comment = text)
     }
   }
 
+  /**
+   * Returns the inclusive end index of the URL within [range] after dropping trailing characters
+   * that are punctuation surrounding the URL rather than part of it. `\S+` greedily swallows a
+   * trailing `),.;` etc. (e.g. `"(https://example.com/a), ..."`), which would otherwise be saved as
+   * a broken URL. A closing bracket is only dropped when it is unbalanced within the match so that
+   * URLs legitimately containing balanced brackets are preserved.
+   */
+  private fun trailingTrimmedEnd(text: String, range: IntRange): Int {
+    var end = range.last
+    while (end > range.first && shouldDropTrailing(text[end], text, range.first, end)) {
+      end--
+    }
+    return end
+  }
+
+  private fun shouldDropTrailing(c: Char, text: String, start: Int, end: Int): Boolean =
+      c in TRAILING_PUNCTUATION ||
+          CLOSING_TO_OPENING[c]?.let { open ->
+            val sub = text.substring(start..end)
+            sub.count { it == open } < sub.count { it == c }
+          } ?: false
+
   companion object {
     private val URL_PATTERN = """https?://\S+""".toRegex(RegexOption.IGNORE_CASE)
+    private val TRAILING_PUNCTUATION = setOf('.', ',', ';', ':', '!', '?', '"', '\'')
+    private val CLOSING_TO_OPENING = mapOf(')' to '(', ']' to '[', '}' to '{')
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/ExtractSharedContentUseCaseImpl.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/ExtractSharedContentUseCaseImpl.kt
@@ -29,7 +29,7 @@ class ExtractSharedContentUseCaseImpl @Inject constructor() : ExtractSharedConte
 
     val urlMatch = URL_PATTERN.find(text)
     return if (urlMatch != null) {
-      val urlRange = urlMatch.range.first..trailingTrimmedEnd(text, urlMatch.range)
+      val urlRange = trimmedUrlRange(text, urlMatch.range)
       val url = text.substring(urlRange)
       val remaining = text.removeRange(urlRange).trim().replace(Regex("\\s{2,}"), " ")
       SharedContent(url = url, comment = remaining.ifBlank { null })
@@ -38,31 +38,7 @@ class ExtractSharedContentUseCaseImpl @Inject constructor() : ExtractSharedConte
     }
   }
 
-  /**
-   * Returns the inclusive end index of the URL within [range] after dropping trailing characters
-   * that are punctuation surrounding the URL rather than part of it. `\S+` greedily swallows a
-   * trailing `),.;` etc. (e.g. `"(https://example.com/a), ..."`), which would otherwise be saved as
-   * a broken URL. A closing bracket is only dropped when it is unbalanced within the match so that
-   * URLs legitimately containing balanced brackets are preserved.
-   */
-  private fun trailingTrimmedEnd(text: String, range: IntRange): Int {
-    var end = range.last
-    while (end > range.first && shouldDropTrailing(text[end], text, range.first, end)) {
-      end--
-    }
-    return end
-  }
-
-  private fun shouldDropTrailing(c: Char, text: String, start: Int, end: Int): Boolean =
-      c in TRAILING_PUNCTUATION ||
-          CLOSING_TO_OPENING[c]?.let { open ->
-            val sub = text.substring(start..end)
-            sub.count { it == open } < sub.count { it == c }
-          } ?: false
-
   companion object {
     private val URL_PATTERN = """https?://\S+""".toRegex(RegexOption.IGNORE_CASE)
-    private val TRAILING_PUNCTUATION = setOf('.', ',', ';', ':', '!', '?', '"', '\'')
-    private val CLOSING_TO_OPENING = mapOf(')' to '(', ']' to '[', '}' to '{')
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/UrlBoundary.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/UrlBoundary.kt
@@ -1,0 +1,29 @@
+package io.github.omochice.pinosu.feature.shareintent.domain.usecase
+
+/**
+ * Narrows a greedily-matched URL [range] within [text] to its true boundary by dropping trailing
+ * characters that are punctuation around the URL rather than part of it. `\S+` greedily swallows a
+ * trailing `),.;` etc. (e.g. `"(https://example.com/a), ..."`), which would otherwise be saved as a
+ * broken URL. A closing bracket is only dropped when it is unbalanced within the match so that URLs
+ * legitimately containing balanced brackets (e.g. Wikipedia `..._(protocol)` links) are preserved.
+ */
+internal fun trimmedUrlRange(text: String, range: IntRange): IntRange =
+    range.first..trailingTrimmedEnd(text, range)
+
+private fun trailingTrimmedEnd(text: String, range: IntRange): Int {
+  var end = range.last
+  while (end > range.first && shouldDropTrailing(text[end], text, range.first, end)) {
+    end--
+  }
+  return end
+}
+
+private fun shouldDropTrailing(c: Char, text: String, start: Int, end: Int): Boolean =
+    c in TRAILING_PUNCTUATION ||
+        CLOSING_TO_OPENING[c]?.let { open ->
+          val sub = text.substring(start..end)
+          sub.count { it == open } < sub.count { it == c }
+        } ?: false
+
+private val TRAILING_PUNCTUATION = setOf('.', ',', ';', ':', '!', '?', '"', '\'')
+private val CLOSING_TO_OPENING = mapOf(')' to '(', ']' to '[', '}' to '{')

--- a/app/src/test/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/ExtractSharedContentUseCaseTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/ExtractSharedContentUseCaseTest.kt
@@ -218,6 +218,46 @@ class ExtractSharedContentUseCaseTest {
   }
 
   @Test
+  fun `URL wrapped in parentheses and trailing comma keeps only the URL`() {
+    val intent =
+        Intent(Intent.ACTION_SEND).apply {
+          type = "text/plain"
+          putExtra(Intent.EXTRA_TEXT, "Great read (https://example.com/article), recommended")
+        }
+
+    val result = useCase(intent)
+    assertEquals(
+        SharedContent(url = "https://example.com/article", comment = "Great read (), recommended"),
+        result)
+  }
+
+  @Test
+  fun `URL followed by sentence punctuation drops the trailing period`() {
+    val intent =
+        Intent(Intent.ACTION_SEND).apply {
+          type = "text/plain"
+          putExtra(Intent.EXTRA_TEXT, "See https://example.com/path.")
+        }
+
+    val result = useCase(intent)
+    assertEquals(SharedContent(url = "https://example.com/path", comment = "See ."), result)
+  }
+
+  @Test
+  fun `URL containing balanced parentheses is preserved`() {
+    val intent =
+        Intent(Intent.ACTION_SEND).apply {
+          type = "text/plain"
+          putExtra(Intent.EXTRA_TEXT, "https://en.wikipedia.org/wiki/Nostr_(protocol)")
+        }
+
+    val result = useCase(intent)
+    assertEquals(
+        SharedContent(url = "https://en.wikipedia.org/wiki/Nostr_(protocol)", comment = null),
+        result)
+  }
+
+  @Test
   fun `URL with query params in text extracts full URL`() {
     val intent =
         Intent(Intent.ACTION_SEND).apply {

--- a/app/src/test/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/UrlBoundaryTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/shareintent/domain/usecase/UrlBoundaryTest.kt
@@ -1,0 +1,43 @@
+package io.github.omochice.pinosu.feature.shareintent.domain.usecase
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UrlBoundaryTest {
+
+  private fun trimmed(text: String): String {
+    val range = GREEDY_URL.find(text)!!.range
+    return text.substring(trimmedUrlRange(text, range))
+  }
+
+  @Test
+  fun `drops trailing sentence punctuation`() {
+    assertEquals("https://example.com/a", trimmed("read https://example.com/a, thanks"))
+  }
+
+  @Test
+  fun `drops a closing bracket that has no opening within the match`() {
+    assertEquals("https://example.com/a", trimmed("see (https://example.com/a) now"))
+  }
+
+  @Test
+  fun `keeps a closing bracket that is balanced within the match`() {
+    val url = "https://en.wikipedia.org/wiki/Foo_(bar)"
+    assertEquals(url, trimmed(url))
+  }
+
+  @Test
+  fun `drops multiple trailing characters`() {
+    assertEquals("https://example.com/a", trimmed("(https://example.com/a)."))
+  }
+
+  @Test
+  fun `keeps a URL with no trailing punctuation unchanged`() {
+    val url = "https://example.com/path"
+    assertEquals(url, trimmed(url))
+  }
+
+  companion object {
+    private val GREEDY_URL = """https?://\S+""".toRegex(RegexOption.IGNORE_CASE)
+  }
+}


### PR DESCRIPTION
## Summary

The shared-URL extractor now trims trailing sentence punctuation and unbalanced closing brackets from the matched URL instead of saving them as part of the link (review finding 5).

## Details

The `https?://\S+` pattern greedily captured any trailing non-whitespace, so sharing text such as `Great read (https://example.com/article), recommended` saved the URL as `https://example.com/article),`, which 404s and breaks metadata fetch.

Brackets that are balanced within the URL (e.g. Wikipedia `..._(protocol)` links) are preserved, and the removed characters remain in the extracted comment.

## Confirmation

Ran `devbox run ./gradlew detekt test` locally and confirmed it is green, including new tests for URLs followed by punctuation, wrapped in parentheses, and containing balanced parentheses.

## Limitation

No known limitations.

https://claude.ai/code/session_01C5raaQMqnpDtTRT5APanLT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared-link detection so copied URLs no longer include nearby trailing punctuation.
  * URLs wrapped in balanced parentheses are now preserved correctly.
  * Extra text around shared links is still separated into a clean comment when present.

* **Tests**
  * Added coverage for URLs followed by punctuation, wrapped in parentheses, and containing balanced parentheses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
