### PR TITLE
fix: report malformed OK accepted flag as a serialization error

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/core/relay/NostrRelayMessage.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/relay/NostrRelayMessage.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
@@ -128,13 +129,16 @@ internal object NostrRelayMessageSerializer : KSerializer<NostrRelayMessage> {
     if (array.size < 3) {
       throw SerializationException("OK message requires at least 3 elements")
     }
+    // Each field is read via `as? JsonPrimitive` rather than `jsonPrimitive`: a structured element
+    // (object/array) makes `jsonPrimitive` throw IllegalStateException, which RelayPool.onMessage
+    // does not guard, so a malformed OK would tear down the socket instead of being reported.
     val eventId =
-        array[1].jsonPrimitive.contentOrNull
+        (array[1] as? JsonPrimitive)?.contentOrNull
             ?: throw SerializationException("Event ID must be a string")
     val accepted =
-        array[2].jsonPrimitive.booleanOrNull
+        (array[2] as? JsonPrimitive)?.booleanOrNull
             ?: throw SerializationException("OK accepted flag must be a boolean")
-    val message = if (array.size > 3) array[3].jsonPrimitive.contentOrNull ?: "" else ""
+    val message = if (array.size > 3) (array[3] as? JsonPrimitive)?.contentOrNull ?: "" else ""
     return NostrRelayMessage.Ok(eventId, accepted, message)
   }
 

--- a/app/src/main/java/io/github/omochice/pinosu/core/relay/NostrRelayMessage.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/relay/NostrRelayMessage.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
-import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
@@ -131,7 +131,9 @@ internal object NostrRelayMessageSerializer : KSerializer<NostrRelayMessage> {
     val eventId =
         array[1].jsonPrimitive.contentOrNull
             ?: throw SerializationException("Event ID must be a string")
-    val accepted = array[2].jsonPrimitive.boolean
+    val accepted =
+        array[2].jsonPrimitive.booleanOrNull
+            ?: throw SerializationException("OK accepted flag must be a boolean")
     val message = if (array.size > 3) array[3].jsonPrimitive.contentOrNull ?: "" else ""
     return NostrRelayMessage.Ok(eventId, accepted, message)
   }

--- a/app/src/test/java/io/github/omochice/pinosu/core/relay/NostrRelayMessageTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/relay/NostrRelayMessageTest.kt
@@ -37,4 +37,26 @@ class NostrRelayMessageTest {
       json.decodeFromString<NostrRelayMessage>("""["OK","event-id","yes","stored"]""")
     }
   }
+
+  @Test
+  fun `OK message with non-primitive accepted flag throws SerializationException`() {
+    assertFailsWith<SerializationException> {
+      json.decodeFromString<NostrRelayMessage>("""["OK","event-id",{},"stored"]""")
+    }
+  }
+
+  @Test
+  fun `OK message with non-primitive event id throws SerializationException`() {
+    assertFailsWith<SerializationException> {
+      json.decodeFromString<NostrRelayMessage>("""["OK",{},true,"stored"]""")
+    }
+  }
+
+  @Test
+  fun `OK message with non-primitive message field is treated as empty`() {
+    val message = json.decodeFromString<NostrRelayMessage>("""["OK","event-id",true,{}]""")
+
+    val ok = message as NostrRelayMessage.Ok
+    assertEquals("", ok.message)
+  }
 }

--- a/app/src/test/java/io/github/omochice/pinosu/core/relay/NostrRelayMessageTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/relay/NostrRelayMessageTest.kt
@@ -30,9 +30,8 @@ class NostrRelayMessageTest {
 
   @Test
   fun `OK message with non-boolean accepted flag throws SerializationException`() {
-    // A value whose content is neither "true" nor "false" (here the string "yes") is what
-    // previously
-    // leaked an IllegalStateException from JsonPrimitive.boolean past the caller's guards.
+    // "yes" is a non-boolean string; JsonPrimitive.boolean used to leak an IllegalStateException
+    // on such values, slipping past the caller's guards.
     assertFailsWith<SerializationException> {
       json.decodeFromString<NostrRelayMessage>("""["OK","event-id","yes","stored"]""")
     }

--- a/app/src/test/java/io/github/omochice/pinosu/core/relay/NostrRelayMessageTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/relay/NostrRelayMessageTest.kt
@@ -1,0 +1,40 @@
+package io.github.omochice.pinosu.core.relay
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+/**
+ * Unit tests for [NostrRelayMessageSerializer] OK message parsing.
+ *
+ * Focuses on the `accepted` flag: a well-formed boolean parses, and a malformed non-boolean flag is
+ * reported as a [SerializationException] so callers that only guard against serialization errors do
+ * not treat it as a transport failure.
+ */
+class NostrRelayMessageTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun `OK message with boolean accepted flag parses`() {
+    val message = json.decodeFromString<NostrRelayMessage>("""["OK","event-id",true,"stored"]""")
+
+    val ok = message as NostrRelayMessage.Ok
+    assertEquals("event-id", ok.eventId)
+    assertTrue(ok.accepted, "accepted should reflect the boolean true")
+    assertEquals("stored", ok.message)
+  }
+
+  @Test
+  fun `OK message with non-boolean accepted flag throws SerializationException`() {
+    // A value whose content is neither "true" nor "false" (here the string "yes") is what
+    // previously
+    // leaked an IllegalStateException from JsonPrimitive.boolean past the caller's guards.
+    assertFailsWith<SerializationException> {
+      json.decodeFromString<NostrRelayMessage>("""["OK","event-id","yes","stored"]""")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The relay `OK` deserializer now raises a `SerializationException` for a non-boolean `accepted` flag instead of an uncaught `IllegalStateException` that tore down the socket (review finding 6).

## Details

`deserializeOk` read the flag with `JsonPrimitive.boolean`, which throws `IllegalStateException` when the value is not a strict boolean.

`RelayPool.onMessage` only guards against `SerializationException` and `IllegalArgumentException`, so a relay sending e.g. `["OK","<id>","yes"]` tore down the socket and a publish was misreported as a connection failure.

Parsing with `booleanOrNull` and raising `SerializationException` matches how the other malformed fields in this deserializer are signalled.

## Confirmation

Ran `devbox run ./gradlew detekt test` locally and confirmed it is green, including a new test asserting that a non-boolean OK flag is surfaced as a serialization error.

## Limitation

No known limitations.

https://claude.ai/code/session_01C5raaQMqnpDtTRT5APanLT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of relay “OK” messages when the acceptance flag is missing or invalid.
  * Invalid acceptance values now fail with a clear validation error instead of an unexpected parsing issue.

* **Tests**
  * Added coverage for successful parsing of valid “OK” messages.
  * Added coverage for invalid acceptance values to ensure deserialization fails as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->