### PR TITLE
fix: persist pending unsigned event across process death

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/core/model/UnsignedNostrEvent.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/model/UnsignedNostrEvent.kt
@@ -96,9 +96,6 @@ data class UnsignedNostrEvent(
     /**
      * Reconstruct an unsigned event from the JSON produced by [toJson]
      *
-     * Used to restore the pending event across process death (persisted in SavedStateHandle) while
-     * an external NIP-55 signer is in the foreground.
-     *
      * @param json JSON string previously produced by [toJson]
      * @return The parsed event, or null if the JSON is malformed
      */

--- a/app/src/main/java/io/github/omochice/pinosu/core/model/UnsignedNostrEvent.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/model/UnsignedNostrEvent.kt
@@ -1,6 +1,8 @@
 package io.github.omochice.pinosu.core.model
 
 import com.vitorpamplona.quartz.nip01Core.crypto.EventHasher
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
@@ -90,5 +92,31 @@ data class UnsignedNostrEvent(
       }
       return unsignedEvent?.toSignedJson(signerResponse)
     }
+
+    /**
+     * Reconstruct an unsigned event from the JSON produced by [toJson]
+     *
+     * Used to restore the pending event across process death (persisted in SavedStateHandle) while
+     * an external NIP-55 signer is in the foreground.
+     *
+     * @param json JSON string previously produced by [toJson]
+     * @return The parsed event, or null if the JSON is malformed
+     */
+    fun fromJson(json: String): UnsignedNostrEvent? =
+        try {
+          val dto = Json.decodeFromString<UnsignedEventDto>(json)
+          UnsignedNostrEvent(dto.pubkey, dto.createdAt, dto.kind, dto.tags, dto.content)
+        } catch (_: IllegalArgumentException) {
+          null
+        }
   }
 }
+
+@Serializable
+private data class UnsignedEventDto(
+    val pubkey: String,
+    @SerialName("created_at") val createdAt: Long,
+    val kind: Int,
+    val tags: List<List<String>>,
+    val content: String,
+)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModel.kt
@@ -1,6 +1,7 @@
 package io.github.omochice.pinosu.feature.postbookmark.presentation.viewmodel
 
 import android.content.Intent
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,19 +23,29 @@ import kotlinx.coroutines.launch
  *
  * @param postBookmarkUseCase UseCase for creating and publishing bookmark events
  * @param nip55SignerClient Client for NIP-55 signer interaction
+ * @param savedStateHandle Handle used to persist the pending unsigned event across process death
  */
 @HiltViewModel
 class PostBookmarkViewModel
 @Inject
 constructor(
     private val postBookmarkUseCase: PostBookmarkUseCase,
-    private val nip55SignerClient: Nip55SignerClient
+    private val nip55SignerClient: Nip55SignerClient,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
   private val _uiState = MutableStateFlow(PostBookmarkUiState())
   val uiState: StateFlow<PostBookmarkUiState> = _uiState.asStateFlow()
 
-  private var pendingUnsignedEvent: UnsignedNostrEvent? = null
+  /**
+   * JSON of the unsigned event awaiting a signature, persisted in [SavedStateHandle] so it survives
+   * process death while the external NIP-55 signer is in the foreground.
+   */
+  private var pendingUnsignedEventJson: String?
+    get() = savedStateHandle[KEY_PENDING_UNSIGNED_EVENT]
+    set(value) {
+      savedStateHandle[KEY_PENDING_UNSIGNED_EVENT] = value
+    }
 
   /**
    * Update URL field
@@ -130,8 +141,8 @@ constructor(
               categories = categories,
               comment = state.comment)
           .onSuccess { unsignedEvent ->
-            pendingUnsignedEvent = unsignedEvent
             val eventJson = unsignedEvent.toJson()
+            pendingUnsignedEventJson = eventJson
             val intent = nip55SignerClient.createSignEventIntent(eventJson)
             onReady(intent)
           }
@@ -168,6 +179,7 @@ constructor(
   }
 
   private suspend fun performPublishSignedEvent(response: SignedEventResponse) {
+    val pendingUnsignedEvent = pendingUnsignedEventJson?.let { UnsignedNostrEvent.fromJson(it) }
     val signedEventJson =
         UnsignedNostrEvent.buildSignedEventJson(response.signedEventJson, pendingUnsignedEvent)
             ?: run {
@@ -183,6 +195,10 @@ constructor(
             it.copy(isSubmitting = false, errorMessage = error.message ?: "ブックマークの投稿に失敗しました")
           }
         }
+  }
+
+  private companion object {
+    const val KEY_PENDING_UNSIGNED_EVENT = "pending_unsigned_event_json"
   }
 }
 

--- a/app/src/test/java/io/github/omochice/pinosu/core/model/UnsignedNostrEventTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/model/UnsignedNostrEventTest.kt
@@ -1,0 +1,34 @@
+package io.github.omochice.pinosu.core.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** Unit tests for [UnsignedNostrEvent] JSON round-tripping used by SavedStateHandle persistence. */
+class UnsignedNostrEventTest {
+
+  @Test
+  fun `fromJson reverses toJson`() {
+    val event =
+        UnsignedNostrEvent(
+            pubkey = "abc123",
+            createdAt = 1_700_000_000L,
+            kind = 39_701,
+            tags = listOf(listOf("d", "example.com"), listOf("t", "tech")),
+            content = "a comment with \"quotes\" and , commas")
+
+    val restored = UnsignedNostrEvent.fromJson(event.toJson())
+
+    assertEquals(event, restored, "fromJson should reconstruct the exact event produced by toJson")
+  }
+
+  @Test
+  fun `fromJson returns null for malformed json`() {
+    assertNull(UnsignedNostrEvent.fromJson("this is not json"))
+  }
+
+  @Test
+  fun `fromJson returns null when required fields are missing`() {
+    assertNull(UnsignedNostrEvent.fromJson("""{"pubkey":"abc"}"""))
+  }
+}

--- a/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
@@ -278,9 +278,8 @@ class PostBookmarkViewModelTest {
     viewModel.prepareSignEventIntent {}
     advanceUntilIdle()
 
-    // Simulate process death while the signer is foregrounded: the original ViewModel is destroyed
-    // and recreated from the same SavedStateHandle. The pending event must be restored so a
-    // signature-only response can still be assembled into a full signed event.
+    // Recreating the ViewModel from the same SavedStateHandle simulates process death while the
+    // signer is foregrounded.
     val revivedViewModel =
         PostBookmarkViewModel(postBookmarkUseCase, nip55SignerClient, savedStateHandle)
 

--- a/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/postbookmark/presentation/viewmodel/PostBookmarkViewModelTest.kt
@@ -1,6 +1,7 @@
 package io.github.omochice.pinosu.feature.postbookmark.presentation.viewmodel
 
 import android.content.Intent
+import androidx.lifecycle.SavedStateHandle
 import io.github.omochice.pinosu.core.model.UnsignedNostrEvent
 import io.github.omochice.pinosu.core.nip.nip55.Nip55SignerClient
 import io.github.omochice.pinosu.core.nip.nip55.SignedEventResponse
@@ -37,6 +38,7 @@ class PostBookmarkViewModelTest {
 
   private lateinit var postBookmarkUseCase: PostBookmarkUseCase
   private lateinit var nip55SignerClient: Nip55SignerClient
+  private lateinit var savedStateHandle: SavedStateHandle
   private lateinit var viewModel: PostBookmarkViewModel
 
   private val testDispatcher = StandardTestDispatcher()
@@ -46,7 +48,8 @@ class PostBookmarkViewModelTest {
     Dispatchers.setMain(testDispatcher)
     postBookmarkUseCase = mockk(relaxed = true)
     nip55SignerClient = mockk(relaxed = true)
-    viewModel = PostBookmarkViewModel(postBookmarkUseCase, nip55SignerClient)
+    savedStateHandle = SavedStateHandle()
+    viewModel = PostBookmarkViewModel(postBookmarkUseCase, nip55SignerClient, savedStateHandle)
   }
 
   @AfterTest
@@ -248,6 +251,46 @@ class PostBookmarkViewModelTest {
     val state = viewModel.uiState.first()
     assertTrue(state.postSuccess, "postSuccess should be true")
     assertFalse(state.isSubmitting, "isSubmitting should be false")
+  }
+
+  @Test
+  fun `pending event survives process death and publishes signature-only response`() = runTest {
+    val realEvent =
+        UnsignedNostrEvent(
+            pubkey = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1",
+            createdAt = 1_234_567_890,
+            kind = 39701,
+            tags = listOf(listOf("d", "example.com")),
+            content = "comment")
+    val signatureOnlyResponse = "a".repeat(128)
+    val mockIntent = mockk<Intent>()
+
+    coEvery { postBookmarkUseCase.createUnsignedEvent(any(), any(), any(), any()) } returns
+        Result.success(realEvent)
+    every { nip55SignerClient.createSignEventIntent(any()) } returns mockIntent
+    every { nip55SignerClient.handleSignEventResponse(any(), any()) } returns
+        Result.success(SignedEventResponse(signatureOnlyResponse))
+    coEvery { postBookmarkUseCase.publishSignedEvent(any()) } returns
+        Result.success(PublishResult("event123", listOf("wss://relay.example.com"), emptyList()))
+
+    viewModel.updateUrl("example.com")
+    advanceUntilIdle()
+    viewModel.prepareSignEventIntent {}
+    advanceUntilIdle()
+
+    // Simulate process death while the signer is foregrounded: the original ViewModel is destroyed
+    // and recreated from the same SavedStateHandle. The pending event must be restored so a
+    // signature-only response can still be assembled into a full signed event.
+    val revivedViewModel =
+        PostBookmarkViewModel(postBookmarkUseCase, nip55SignerClient, savedStateHandle)
+
+    revivedViewModel.processSignedEvent(-1, mockIntent)
+    advanceUntilIdle()
+
+    val state = revivedViewModel.uiState.first()
+    assertTrue(state.postSuccess, "revived ViewModel should rebuild and publish the signed event")
+    assertNull(state.errorMessage, "no build failure should be reported after process death")
+    coVerify { postBookmarkUseCase.publishSignedEvent(any()) }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Persist the pending unsigned event across process death so a signature-only NIP-55 response can still be assembled.

## Details

`pendingUnsignedEvent` previously lived only in a plain ViewModel field, so when the OS killed the process under memory pressure while the external NIP-55 signer was in the foreground, the event was lost.

On return, the signer's signature-only response could no longer be assembled and publishing failed despite the user having approved the signature.

The unsigned event is now persisted as JSON in `SavedStateHandle` and restored via a new `UnsignedNostrEvent.fromJson`, addressing review finding 7.

## Confirmation

Ran `devbox run ./gradlew detekt test` locally; all green.

Added a regression test that rebuilds the ViewModel from the same `SavedStateHandle` and confirms a signature-only response still publishes.

## Limitation

No known limitations.

https://claude.ai/code/session_01KymzQo19a8H3xq6WPBLyCg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserves pending post-bookmark signing information when the app is recreated or resumed after process termination.
  * Reconstructs unsigned event data from JSON when completing the signing flow.
* **Bug Fixes**
  * Prevents pending signed-event publishing from failing after process death.
* **Tests**
  * Added coverage for event JSON conversion, invalid input handling, and signing-flow recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->