### PR TITLE
fix: match nevent references using the bech32 character set

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventResolver.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventResolver.kt
@@ -30,6 +30,11 @@ class Nip19EventResolver @Inject constructor() {
   }
 
   companion object {
-    private val NEVENT_PATTERN = Regex("""nostr:nevent1[a-z0-9]+""")
+    // The data part restricts to the bech32 character set (which excludes 1, b, i and o) rather
+    // than
+    // [a-z0-9]. Those four characters can never appear in a valid nevent, so this stops the greedy
+    // match from swallowing directly adjacent words that would otherwise corrupt the encoded value
+    // and make an otherwise valid quoted event fail to decode.
+    private val NEVENT_PATTERN = Regex("""nostr:nevent1[ac-hj-np-z02-9]+""")
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventResolver.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventResolver.kt
@@ -30,10 +30,8 @@ class Nip19EventResolver @Inject constructor() {
   }
 
   companion object {
-    // The data part uses the bech32 character set (which excludes 1, b, i and o) rather than
-    // [a-z0-9]. Those four characters can never appear in a valid nevent, so the match ends at
-    // directly adjacent words instead of swallowing them, which would corrupt the encoded value
-    // and make an otherwise valid quoted event fail to decode.
+    // The bech32 alphabet, not [a-z0-9]: the wider class would let the greedy match swallow
+    // directly adjacent words, corrupting the nevent so it fails to decode.
     private val NEVENT_PATTERN = Regex("""nostr:nevent1[ac-hj-np-z02-9]+""")
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventResolver.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventResolver.kt
@@ -30,10 +30,9 @@ class Nip19EventResolver @Inject constructor() {
   }
 
   companion object {
-    // The data part restricts to the bech32 character set (which excludes 1, b, i and o) rather
-    // than
-    // [a-z0-9]. Those four characters can never appear in a valid nevent, so this stops the greedy
-    // match from swallowing directly adjacent words that would otherwise corrupt the encoded value
+    // The data part uses the bech32 character set (which excludes 1, b, i and o) rather than
+    // [a-z0-9]. Those four characters can never appear in a valid nevent, so the match ends at
+    // directly adjacent words instead of swallowing them, which would corrupt the encoded value
     // and make an otherwise valid quoted event fail to decode.
     private val NEVENT_PATTERN = Regex("""nostr:nevent1[ac-hj-np-z02-9]+""")
   }

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventResolverTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip19/Nip19EventResolverTest.kt
@@ -56,6 +56,18 @@ class Nip19EventResolverTest {
   }
 
   @Test
+  fun `extractEventIds extracts nevent immediately followed by non-bech32 text`() {
+    // "boom" begins with 'b', which is not a bech32 character, so the match must stop at the end of
+    // the nevent. Previously [a-z0-9] absorbed "boom", corrupting the value and dropping the event.
+    val content = "${validNevent}boom"
+
+    val ids = resolver.extractEventIds(content)
+
+    assertEquals(1, ids.size)
+    assertEquals(validNeventHex, ids[0])
+  }
+
+  @Test
   fun `extractEventIds ignores malformed nostr URIs`() {
     val content = "nostr:invalid123 and nostr:npub1abc"
 


### PR DESCRIPTION
## Summary

Restrict the nevent reference pattern to the bech32 character set so adjacent text no longer corrupts the match.

## Details

The pattern used `[a-z0-9]` for the data part, which includes the four characters (`1`, `b`, `i`, `o`) that bech32 never produces.

With no delimiter after a nevent, the greedy match swallowed the following word, corrupting the encoded value so `Nip19Parser` failed to decode it and a valid quoted event silently disappeared from comment quote cards.

Restricting the data part to the bech32 character set makes adjacent non-bech32 text end the match, addressing review finding 8.

## Confirmation

Ran `devbox run ./gradlew detekt test` locally; all green.

Added a regression test that the event ID is still extracted from a nevent immediately followed by non-bech32 text.

## Limitation

No known limitations.

https://claude.ai/code/session_01KymzQo19a8H3xq6WPBLyCg
