### PR TITLE
fix: fetch comments referencing the bookmark via #A or #a

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -23,13 +23,13 @@ import kotlinx.serialization.json.Json
 @Serializable
 private data class RootScopeCommentFilter(
     val kinds: List<Int>,
-    @SerialName("#A") val rootAddress: List<String>,
+    @SerialName("#" + Nip22.Tag.ADDRESS_ROOT) val rootAddress: List<String>,
 )
 
 @Serializable
 private data class ParentScopeCommentFilter(
     val kinds: List<Int>,
-    @SerialName("#a") val parentAddress: List<String>,
+    @SerialName("#" + Nip22.Tag.ADDRESS) val parentAddress: List<String>,
 )
 
 @Serializable

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -21,9 +21,15 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 @Serializable
-private data class CommentFilter(
+private data class RootScopeCommentFilter(
     val kinds: List<Int>,
-    @SerialName("#A") val aTag: List<String>,
+    @SerialName("#A") val rootAddress: List<String>,
+)
+
+@Serializable
+private data class ParentScopeCommentFilter(
+    val kinds: List<Int>,
+    @SerialName("#a") val parentAddress: List<String>,
 )
 
 @Serializable
@@ -53,12 +59,14 @@ constructor(
     return try {
       val relays = relayListProvider.getRelays()
       val addressTagValue = NipB0.createAddress(rootPubkey, identifier)
+      // Match the bookmark address in either the uppercase root scope (#A) or the lowercase parent
+      // scope (#a). A single relay filter ANDs distinct tag keys, so the two scopes are supplied as
+      // separate filters in one REQ (logical OR); RelayPool deduplicates the merged events by id.
+      val kinds = listOf(Nip22.KIND_COMMENT)
       val filter =
-          Json.encodeToString(
-              CommentFilter(
-                  kinds = listOf(Nip22.KIND_COMMENT),
-                  aTag = listOf(addressTagValue),
-              ))
+          Json.encodeToString(RootScopeCommentFilter(kinds, listOf(addressTagValue))) +
+              "," +
+              Json.encodeToString(ParentScopeCommentFilter(kinds, listOf(addressTagValue)))
 
       val events = relayPool.subscribeWithTimeout(relays, filter, RelayPool.PER_RELAY_TIMEOUT_MS)
 

--- a/app/src/test/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepositoryTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepositoryTest.kt
@@ -92,7 +92,7 @@ class RelayCommentRepositoryTest {
   }
 
   @Test
-  fun `getCommentsForBookmark constructs correct NIP-22 A-tag filter`() = runTest {
+  fun `getCommentsForBookmark queries both root and parent address scopes`() = runTest {
     val filterSlot = slot<String>()
     coEvery { relayPool.subscribeWithTimeout(any(), capture(filterSlot), any()) } returns
         emptyList()
@@ -101,7 +101,14 @@ class RelayCommentRepositoryTest {
 
     val filter = filterSlot.captured
     assertTrue(filter.contains("\"kinds\":[1111]"))
-    assertTrue(filter.contains(""""#A":["39701:abc123:example.com/article"]"""))
+    assertTrue(
+        filter.contains(""""#A":["39701:abc123:example.com/article"]"""),
+        "should query the uppercase root scope",
+    )
+    assertTrue(
+        filter.contains(""""#a":["39701:abc123:example.com/article"]"""),
+        "should also query the lowercase parent scope so #a-only references are not missed",
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fetch comments that reference the bookmark via the lowercase `#a` tag in addition to the uppercase `#A` tag.

## Details

`getCommentsForBookmark` filtered kind:1111 comments only by the uppercase root-scope tag `#A`, so comments from clients that reference the bookmark via the lowercase parent-scope tag `#a` were never retrieved.

Because a single relay filter ANDs distinct tag keys, both scopes are queried as separate filters in one REQ (logical OR); `RelayPool` already deduplicates the merged events by id.

This addresses review finding 9 (marked PLAUSIBLE in the review).

## Confirmation

Ran `devbox run ./gradlew detekt test` locally; all green.

Ran `devbox run ./gradlew connectedAndroidTest` on an API 34 emulator against the full stack; all green.

## Limitation

No known limitations.

https://claude.ai/code/session_01KymzQo19a8H3xq6WPBLyCg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bookmarked comment retrieval to include references from both root and parent address scopes.
  * Prevented comments from being missed when they use the lowercase parent-scope format.

* **Tests**
  * Expanded coverage to verify that both address scopes are queried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->