### PR TITLE
fix: stop pagination when a page adds no new items

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
@@ -189,9 +189,8 @@ constructor(
               _uiState.updateTab(mode) { current ->
                 val existingIds = current.items.mapNotNull { it.eventId }.toSet()
                 val uniqueNewItems = newItems.filter { it.eventId !in existingIds }
-                // Stop when a page adds no new items. With the inclusive `until = oldest` cursor a
-                // saturated boundary second can return a full page of already-seen events, leaving
-                // the cursor unchanged; continuing would refetch that same page without advancing.
+                // Without this, a timestamp saturated with a full page of events would make the
+                // inclusive `until = oldest` cursor refetch that same all-duplicate page forever.
                 current.copy(
                     isLoadingMore = false,
                     items = current.items + uniqueNewItems,

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModel.kt
@@ -189,10 +189,13 @@ constructor(
               _uiState.updateTab(mode) { current ->
                 val existingIds = current.items.mapNotNull { it.eventId }.toSet()
                 val uniqueNewItems = newItems.filter { it.eventId !in existingIds }
+                // Stop when a page adds no new items. With the inclusive `until = oldest` cursor a
+                // saturated boundary second can return a full page of already-seen events, leaving
+                // the cursor unchanged; continuing would refetch that same page without advancing.
                 current.copy(
                     isLoadingMore = false,
                     items = current.items + uniqueNewItems,
-                    hasMoreItems = bookmarkList?.hasMore ?: false)
+                    hasMoreItems = uniqueNewItems.isNotEmpty() && bookmarkList?.hasMore == true)
               }
             },
             onFailure = { _uiState.updateTab(mode) { it.copy(isLoadingMore = false) } })

--- a/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModelTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/presentation/viewmodel/BookmarkViewModelTest.kt
@@ -469,33 +469,31 @@ class BookmarkViewModelTest {
   }
 
   @Test
-  fun `loadMore keeps hasMoreItems when a page is all duplicates but relay reports more`() =
-      runTest {
-        val testUser = User(Pubkey.parse(testNpub)!!)
-        val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L) }
+  fun `loadMore stops pagination when a page adds no new items`() = runTest {
+    val testUser = User(Pubkey.parse(testNpub)!!)
+    val initialBookmarks = (1..10).map { i -> bookmark("id$i", 1_700_000_000L) }
 
-        coEvery { getLoginStateUseCase() } returns testUser
-        coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
-            {
-              // Both pages return the same boundary events (shared oldest timestamp, inclusive
-              // until). hasMore stays true, so pagination must not be stopped just because the page
-              // added no new unique items.
-              Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
-            }
+    coEvery { getLoginStateUseCase() } returns testUser
+    coEvery { getBookmarkListUseCase(any(), any()) } coAnswers
+        {
+          // Every page returns the same boundary events (shared oldest timestamp, inclusive until),
+          // so the cursor never advances. Pagination must stop instead of refetching the same page.
+          Result.success(BookmarkList("test", initialBookmarks, 0L, hasMore = true))
+        }
 
-        viewModel.loadTab(BookmarkFilterMode.Local)
-        advanceUntilIdle()
+    viewModel.loadTab(BookmarkFilterMode.Local)
+    advanceUntilIdle()
 
-        viewModel.loadMore(BookmarkFilterMode.Local)
-        advanceUntilIdle()
+    viewModel.loadMore(BookmarkFilterMode.Local)
+    advanceUntilIdle()
 
-        val state = viewModel.uiState.first()
-        assertEquals(10, state.local.items.size, "duplicates should not be appended")
-        assertTrue(
-            state.local.hasMoreItems,
-            "hasMoreItems should follow the relay hint, not the unique-item count",
-        )
-      }
+    val state = viewModel.uiState.first()
+    assertEquals(10, state.local.items.size, "duplicates should not be appended")
+    assertFalse(
+        state.local.hasMoreItems,
+        "hasMoreItems should be false once a page adds no new items so it cannot get stuck",
+    )
+  }
 
   @Test
   fun `loadMore stops pagination when logged out mid-session`() = runTest {


### PR DESCRIPTION
## Summary

Stop bookmark pagination once a page returns no new items so it can no longer get stuck refetching the same boundary page.

## Details

This is a follow-up to a review comment on the merged #609, where `loadMore` reused the oldest `createdAt` as an inclusive `until` cursor and deduplicated by `eventId`, so a full page of events sharing the oldest timestamp returned only already-seen items and left both the cursor and the item list unchanged while `hasMoreItems` stayed true.

Stopping when a page adds nothing new terminates cleanly and, written as `uniqueNewItems.isNotEmpty() && bookmarkList?.hasMore == true`, also keeps the boolean unambiguous; advancing the cursor instead would need extra pagination state and only helps the pathological case of more than a page of events in a single second.

## Confirmation

Ran `devbox run ./gradlew detekt test` locally and it passed, including the updated test that now asserts pagination stops on an all-duplicate page.

## Limitation

A single second holding more than one page of events can still leave the overflow beyond the first page unreachable, which is inherent to `limit`+`until` pagination over duplicate timestamps.

https://claude.ai/code/session_01KymzQo19a8H3xq6WPBLyCg