### PR TITLE
refactor: accept multiple filters in relay subscriptions

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip01/Nip01ProfileFetcher.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip01/Nip01ProfileFetcher.kt
@@ -70,7 +70,8 @@ constructor(
         Json.encodeToString(
             ProfileFilter(
                 kinds = listOf(Nip01ProfileParserImpl.KIND_USER_METADATA), authors = uncached))
-    val events = relayPool.subscribeWithTimeout(relays, filter, RelayPool.PER_RELAY_TIMEOUT_MS)
+    val events =
+        relayPool.subscribeWithTimeout(relays, listOf(filter), RelayPool.PER_RELAY_TIMEOUT_MS)
 
     val profilesByPubkey =
         events

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip65/Nip65RelayListFetcher.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip65/Nip65RelayListFetcher.kt
@@ -102,7 +102,7 @@ constructor(
   private suspend fun queryRelay(relay: RelayConfig, filter: String): List<RelayConfig>? {
     val events =
         try {
-          relayPool.subscribeWithTimeout(listOf(relay), filter, RELAY_TIMEOUT_MS)
+          relayPool.subscribeWithTimeout(listOf(relay), listOf(filter), RELAY_TIMEOUT_MS)
         } catch (_: IOException) {
           return null
         }

--- a/app/src/main/java/io/github/omochice/pinosu/core/relay/RelayPool.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/relay/RelayPool.kt
@@ -40,13 +40,13 @@ interface RelayPool {
    * returns the merged result.
    *
    * @param relays List of relay configurations to query
-   * @param filter Nostr filter as JSON string
+   * @param filters Nostr filters as JSON strings; a relay ORs multiple filters within one REQ
    * @param timeoutMs Timeout in milliseconds for each relay
    * @return List of deduplicated events from all relays
    */
   suspend fun subscribeWithTimeout(
       relays: List<RelayConfig>,
-      filter: String,
+      filters: List<String>,
       timeoutMs: Long
   ): List<NostrEvent>
 
@@ -81,10 +81,10 @@ class RelayPoolImpl @Inject constructor(private val okHttpClient: OkHttpClient) 
 
   override suspend fun subscribeWithTimeout(
       relays: List<RelayConfig>,
-      filter: String,
+      filters: List<String>,
       timeoutMs: Long
   ): List<NostrEvent> {
-    if (relays.isEmpty()) {
+    if (relays.isEmpty() || filters.isEmpty()) {
       return emptyList()
     }
 
@@ -93,7 +93,7 @@ class RelayPoolImpl @Inject constructor(private val okHttpClient: OkHttpClient) 
           relays.map { relay ->
             async {
               try {
-                withTimeoutOrNull(timeoutMs) { subscribeToRelay(relay.url, filter).toList() }
+                withTimeoutOrNull(timeoutMs) { subscribeToRelay(relay.url, filters).toList() }
                     ?: emptyList()
               } catch (e: IOException) {
                 Log.w(TAG, "Failed to fetch from relay ${relay.url}: ${e.message}")
@@ -243,48 +243,49 @@ class RelayPoolImpl @Inject constructor(private val okHttpClient: OkHttpClient) 
    * Subscribe to events from a single relay
    *
    * @param relayUrl WebSocket URL of the relay
-   * @param filter Nostr filter as JSON string
+   * @param filters Nostr filters as JSON strings, sent as separate elements of the REQ message
    * @return Flow of events from the relay
    */
-  private fun subscribeToRelay(relayUrl: String, filter: String): Flow<NostrEvent> = callbackFlow {
-    val subscriptionId = UUID.randomUUID().toString()
-    val request = Request.Builder().url(relayUrl).build()
+  private fun subscribeToRelay(relayUrl: String, filters: List<String>): Flow<NostrEvent> =
+      callbackFlow {
+        val subscriptionId = UUID.randomUUID().toString()
+        val request = Request.Builder().url(relayUrl).build()
 
-    val listener =
-        object : WebSocketListener() {
-          override fun onOpen(webSocket: WebSocket, response: Response) {
-            val reqMessage = """["REQ","$subscriptionId",$filter]"""
-            webSocket.send(reqMessage)
-          }
-
-          override fun onMessage(webSocket: WebSocket, text: String) {
-            try {
-              when (val message = json.decodeFromString<NostrRelayMessage>(text)) {
-                is NostrRelayMessage.Event -> trySend(message.event)
-                is NostrRelayMessage.Eose -> webSocket.close(1000, "EOSE received")
-                is NostrRelayMessage.Closed -> close()
-                else -> {}
+        val listener =
+            object : WebSocketListener() {
+              override fun onOpen(webSocket: WebSocket, response: Response) {
+                val reqMessage = """["REQ","$subscriptionId",${filters.joinToString(",")}]"""
+                webSocket.send(reqMessage)
               }
-            } catch (e: IllegalArgumentException) {
-              Log.e(TAG, "Error parsing message from $relayUrl: $text", e)
-              close(e)
+
+              override fun onMessage(webSocket: WebSocket, text: String) {
+                try {
+                  when (val message = json.decodeFromString<NostrRelayMessage>(text)) {
+                    is NostrRelayMessage.Event -> trySend(message.event)
+                    is NostrRelayMessage.Eose -> webSocket.close(1000, "EOSE received")
+                    is NostrRelayMessage.Closed -> close()
+                    else -> {}
+                  }
+                } catch (e: IllegalArgumentException) {
+                  Log.e(TAG, "Error parsing message from $relayUrl: $text", e)
+                  close(e)
+                }
+              }
+
+              override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                Log.w(TAG, "WebSocket failure for $relayUrl: ${t.message}")
+                close(t)
+              }
+
+              override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                close()
+              }
             }
-          }
 
-          override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-            Log.w(TAG, "WebSocket failure for $relayUrl: ${t.message}")
-            close(t)
-          }
+        val webSocket = okHttpClient.newWebSocket(request, listener)
 
-          override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
-            close()
-          }
-        }
-
-    val webSocket = okHttpClient.newWebSocket(request, listener)
-
-    awaitClose { webSocket.close(1000, "Flow cancelled") }
-  }
+        awaitClose { webSocket.close(1000, "Flow cancelled") }
+      }
 
   companion object {
     private const val TAG = "RelayPool"

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepository.kt
@@ -66,7 +66,8 @@ constructor(
       val untilClause = until?.let { ""","until":$it""" } ?: ""
       val filter =
           """{"kinds":[${NipB0.KIND_BOOKMARK_LIST}],"limit":$PAGE_SIZE$authorsClause$untilClause}"""
-      val events = relayPool.subscribeWithTimeout(relays, filter, RelayPool.PER_RELAY_TIMEOUT_MS)
+      val events =
+          relayPool.subscribeWithTimeout(relays, listOf(filter), RelayPool.PER_RELAY_TIMEOUT_MS)
 
       if (events.isEmpty()) {
         Result.success(null)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepository.kt
@@ -63,12 +63,12 @@ constructor(
       // scope (#a). A single relay filter ANDs distinct tag keys, so the two scopes are supplied as
       // separate filters in one REQ (logical OR); RelayPool deduplicates the merged events by id.
       val kinds = listOf(Nip22.KIND_COMMENT)
-      val filter =
-          Json.encodeToString(RootScopeCommentFilter(kinds, listOf(addressTagValue))) +
-              "," +
-              Json.encodeToString(ParentScopeCommentFilter(kinds, listOf(addressTagValue)))
+      val filters =
+          listOf(
+              Json.encodeToString(RootScopeCommentFilter(kinds, listOf(addressTagValue))),
+              Json.encodeToString(ParentScopeCommentFilter(kinds, listOf(addressTagValue))))
 
-      val events = relayPool.subscribeWithTimeout(relays, filter, RelayPool.PER_RELAY_TIMEOUT_MS)
+      val events = relayPool.subscribeWithTimeout(relays, filters, RelayPool.PER_RELAY_TIMEOUT_MS)
 
       val comments =
           events.map { event ->
@@ -128,7 +128,8 @@ constructor(
       val relays = relayListProvider.getRelays()
       val filter = Json.encodeToString(EventIdFilter(ids = ids))
 
-      val events = relayPool.subscribeWithTimeout(relays, filter, RelayPool.PER_RELAY_TIMEOUT_MS)
+      val events =
+          relayPool.subscribeWithTimeout(relays, listOf(filter), RelayPool.PER_RELAY_TIMEOUT_MS)
       Result.success(events)
     } catch (e: IOException) {
       Log.e(TAG, "Error fetching events by IDs", e)

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip01/Nip01ProfileFetcherTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip01/Nip01ProfileFetcherTest.kt
@@ -135,7 +135,10 @@ class Nip01ProfileFetcherTest {
     coVerify {
       relayPool.subscribeWithTimeout(
           any(),
-          match { it.contains(""""kinds":[0]""") && it.contains(""""authors":["aabb","ccdd"]""") },
+          match {
+            it.single().contains(""""kinds":[0]""") &&
+                it.single().contains(""""authors":["aabb","ccdd"]""")
+          },
           any())
     }
   }

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip65/Nip65RelayListFetcherTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip65/Nip65RelayListFetcherTest.kt
@@ -67,7 +67,10 @@ class Nip65RelayListFetcherTest {
     coVerify {
       relayPool.subscribeWithTimeout(
           any(),
-          match { it.contains("\"kinds\":[10002]") && it.contains("\"authors\":[\"$hexPubkey\"]") },
+          match {
+            it.single().contains("\"kinds\":[10002]") &&
+                it.single().contains("\"authors\":[\"$hexPubkey\"]")
+          },
           any())
     }
   }

--- a/app/src/test/java/io/github/omochice/pinosu/core/relay/FakeRelayPoolTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/relay/FakeRelayPoolTest.kt
@@ -24,7 +24,7 @@ class FakeRelayPoolTest {
     val result =
         fakeRelayPool.subscribeWithTimeout(
             relays = listOf(RelayConfig("wss://relay.example.com")),
-            filter = """{"kinds":[1]}""",
+            filters = listOf("""{"kinds":[1]}"""),
             timeoutMs = 1000)
 
     assertEquals(listOf(event), result)
@@ -34,15 +34,15 @@ class FakeRelayPoolTest {
   fun subscribeWithTimeout_recordsCallArguments() = runTest {
     val relays =
         listOf(RelayConfig("wss://relay1.example.com"), RelayConfig("wss://relay2.example.com"))
-    val filter = """{"kinds":[1],"limit":10}"""
+    val filters = listOf("""{"kinds":[1],"limit":10}""")
     val timeoutMs = 5000L
 
-    fakeRelayPool.subscribeWithTimeout(relays, filter, timeoutMs)
+    fakeRelayPool.subscribeWithTimeout(relays, filters, timeoutMs)
 
     assertEquals(1, fakeRelayPool.subscribeCallArgs.size)
     val call = fakeRelayPool.subscribeCallArgs.first()
     assertEquals(relays, call.relays)
-    assertEquals(filter, call.filter)
+    assertEquals(filters, call.filters)
     assertEquals(timeoutMs, call.timeoutMs)
   }
 
@@ -105,7 +105,7 @@ class FakeRelayPoolTest {
                 eventId = "test",
                 successfulRelays = listOf("wss://relay.example.com"),
                 failedRelays = emptyList()))
-    fakeRelayPool.subscribeWithTimeout(emptyList(), "{}", 1000)
+    fakeRelayPool.subscribeWithTimeout(emptyList(), listOf("{}"), 1000)
     fakeRelayPool.publishEvent(emptyList(), "{}", 1000)
 
     fakeRelayPool.reset()

--- a/app/src/test/java/io/github/omochice/pinosu/core/relay/RelayPoolTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/relay/RelayPoolTest.kt
@@ -60,6 +60,7 @@ class RelayPoolTest {
    */
   private inner class MockWebSocketState(private val events: List<NostrEvent>) {
     val ws: WebSocket = mockk(relaxed = true)
+    val sentMessages = java.util.concurrent.CopyOnWriteArrayList<String>()
     private val closed = java.util.concurrent.atomic.AtomicBoolean(false)
 
     @Volatile private var wsListener: WebSocketListener? = null
@@ -68,6 +69,7 @@ class RelayPoolTest {
       every { ws.send(any<String>()) } answers
           {
             val message = firstArg<String>()
+            sentMessages.add(message)
             val currentListener = wsListener
 
             if (currentListener != null && message.startsWith("[\"REQ\"")) {
@@ -170,7 +172,7 @@ class RelayPoolTest {
 
     val filter = """{"kinds":[39701],"limit":10}"""
 
-    val result = relayPool.subscribeWithTimeout(relays, filter, 5000L)
+    val result = relayPool.subscribeWithTimeout(relays, listOf(filter), 5000L)
 
     assertEquals(2, result.size, "Should have 2 events")
     assertTrue(result.any { it.id == "event1" }, "Should contain event1")
@@ -211,7 +213,7 @@ class RelayPoolTest {
 
     val filter = """{"kinds":[39701],"limit":10}"""
 
-    val result = relayPool.subscribeWithTimeout(relays, filter, 5000L)
+    val result = relayPool.subscribeWithTimeout(relays, listOf(filter), 5000L)
 
     assertEquals(1, result.size, "Should have only 1 event after deduplication")
     assertEquals("same-event-id", result.first().id, "Event ID should be same-event-id")
@@ -232,7 +234,7 @@ class RelayPoolTest {
     val relays = listOf(RelayConfig(url = "wss://relay.example.com"))
     val filter = """{"kinds":[39701],"limit":10}"""
 
-    val result = relayPool.subscribeWithTimeout(relays, filter, 5000L)
+    val result = relayPool.subscribeWithTimeout(relays, listOf(filter), 5000L)
 
     assertEquals(1, result.size, "Should have 1 event")
     assertEquals("single-event", result.first().id, "Event ID should be single-event")
@@ -253,16 +255,50 @@ class RelayPoolTest {
     val relays = listOf(RelayConfig(url = "wss://relay.example.com"))
     val filter = """{"kinds":[39701],"limit":10}"""
 
-    val result = relayPool.subscribeWithTimeout(relays, filter, 5000L)
+    val result = relayPool.subscribeWithTimeout(relays, listOf(filter), 5000L)
 
     assertTrue(result.isEmpty(), "Should return empty list when all relays fail")
   }
 
   @Test
   fun `subscribeWithTimeout with empty relay list should return empty list`() = runBlocking {
-    val result = relayPool.subscribeWithTimeout(emptyList(), """{"kinds":[39701]}""", 5000L)
+    val result = relayPool.subscribeWithTimeout(emptyList(), listOf("""{"kinds":[39701]}"""), 5000L)
 
     assertTrue(result.isEmpty(), "Should return empty list for empty relay list")
+  }
+
+  @Test
+  fun `subscribeWithTimeout with empty filter list should return empty list`() = runBlocking {
+    val relays = listOf(RelayConfig(url = "wss://relay.example.com"))
+
+    val result = relayPool.subscribeWithTimeout(relays, emptyList(), 5000L)
+
+    assertTrue(result.isEmpty(), "Should return empty list for empty filter list")
+  }
+
+  @Test
+  fun `subscribeWithTimeout should send each filter as its own REQ element`() = runBlocking {
+    val state = MockWebSocketState(emptyList())
+
+    every { okHttpClient.newWebSocket(any(), any()) } answers
+        {
+          val listener = secondArg<WebSocketListener>()
+          state.setListener(listener)
+          state.triggerOpen()
+          state.ws
+        }
+
+    val relays = listOf(RelayConfig(url = "wss://relay.example.com"))
+    val rootFilter = """{"kinds":[1111],"#A":["addr"]}"""
+    val parentFilter = """{"kinds":[1111],"#a":["addr"]}"""
+
+    relayPool.subscribeWithTimeout(relays, listOf(rootFilter, parentFilter), 5000L)
+
+    val reqMessage = state.sentMessages.first { it.startsWith("""["REQ"""") }
+    val reqArray = Json.parseToJsonElement(reqMessage).jsonArray
+    assertEquals(4, reqArray.size, "REQ should contain the subscription ID and both filters")
+    assertEquals(Json.parseToJsonElement(rootFilter), reqArray[2])
+    assertEquals(Json.parseToJsonElement(parentFilter), reqArray[3])
   }
 
   @Test
@@ -298,7 +334,7 @@ class RelayPoolTest {
 
     val filter = """{"kinds":[39701],"limit":10}"""
 
-    val result = relayPool.subscribeWithTimeout(relays, filter, 5000L)
+    val result = relayPool.subscribeWithTimeout(relays, listOf(filter), 5000L)
 
     assertEquals(1, result.size, "Should have 1 event from working relay")
     assertEquals("working-event", result.first().id, "Event should be from working relay")

--- a/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepositoryTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/bookmark/data/repository/RelayBookmarkRepositoryTest.kt
@@ -193,7 +193,7 @@ class RelayBookmarkRepositoryTest {
 
     coVerify {
       relayPool.subscribeWithTimeout(
-          any(), match { it.contains("\"until\":$untilTimestamp") }, any())
+          any(), match { it.single().contains("\"until\":$untilTimestamp") }, any())
     }
   }
 
@@ -217,7 +217,9 @@ class RelayBookmarkRepositoryTest {
 
     repository.getBookmarkList(TEST_VALID_NPUB)
 
-    coVerify { relayPool.subscribeWithTimeout(any(), match { !it.contains("\"until\"") }, any()) }
+    coVerify {
+      relayPool.subscribeWithTimeout(any(), match { !it.single().contains("\"until\"") }, any())
+    }
   }
 
   @Test
@@ -228,7 +230,9 @@ class RelayBookmarkRepositoryTest {
 
     repository.getBookmarkList(TEST_VALID_NPUB)
 
-    coVerify { relayPool.subscribeWithTimeout(any(), match { it.contains("\"authors\"") }, any()) }
+    coVerify {
+      relayPool.subscribeWithTimeout(any(), match { it.single().contains("\"authors\"") }, any())
+    }
   }
 
   @Test
@@ -239,7 +243,9 @@ class RelayBookmarkRepositoryTest {
 
     repository.getBookmarkList(authorPubkey = null)
 
-    coVerify { relayPool.subscribeWithTimeout(any(), match { !it.contains("\"authors\"") }, any()) }
+    coVerify {
+      relayPool.subscribeWithTimeout(any(), match { !it.single().contains("\"authors\"") }, any())
+    }
   }
 
   @Test

--- a/app/src/test/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepositoryTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/comment/data/repository/RelayCommentRepositoryTest.kt
@@ -93,20 +93,21 @@ class RelayCommentRepositoryTest {
 
   @Test
   fun `getCommentsForBookmark queries both root and parent address scopes`() = runTest {
-    val filterSlot = slot<String>()
-    coEvery { relayPool.subscribeWithTimeout(any(), capture(filterSlot), any()) } returns
+    val filtersSlot = slot<List<String>>()
+    coEvery { relayPool.subscribeWithTimeout(any(), capture(filtersSlot), any()) } returns
         emptyList()
 
     repository.getCommentsForBookmark(rootPubkey = "abc123", identifier = "example.com/article")
 
-    val filter = filterSlot.captured
-    assertTrue(filter.contains("\"kinds\":[1111]"))
+    val filters = filtersSlot.captured
+    assertEquals(2, filters.size, "each scope should be its own filter")
+    assertTrue(filters.all { it.contains("\"kinds\":[1111]") })
     assertTrue(
-        filter.contains(""""#A":["39701:abc123:example.com/article"]"""),
+        filters.any { it.contains(""""#A":["39701:abc123:example.com/article"]""") },
         "should query the uppercase root scope",
     )
     assertTrue(
-        filter.contains(""""#a":["39701:abc123:example.com/article"]"""),
+        filters.any { it.contains(""""#a":["39701:abc123:example.com/article"]""") },
         "should also query the lowercase parent scope so #a-only references are not missed",
     )
   }
@@ -169,8 +170,8 @@ class RelayCommentRepositoryTest {
             content = "Hello world",
             sig = "dummy-sig")
 
-    val filterSlot = slot<String>()
-    coEvery { relayPool.subscribeWithTimeout(any(), capture(filterSlot), any()) } returns
+    val filtersSlot = slot<List<String>>()
+    coEvery { relayPool.subscribeWithTimeout(any(), capture(filtersSlot), any()) } returns
         listOf(event)
 
     val result = repository.getEventsByIds(listOf("abc123"))
@@ -182,7 +183,7 @@ class RelayCommentRepositoryTest {
     assertEquals("Hello world", events[0].content)
     assertEquals(1, events[0].kind)
 
-    val filter = filterSlot.captured
+    val filter = filtersSlot.captured.single()
     assertTrue(filter.contains(""""ids":["abc123"]"""))
   }
 

--- a/app/src/testFixtures/java/io/github/omochice/pinosu/core/relay/FakeRelayPool.kt
+++ b/app/src/testFixtures/java/io/github/omochice/pinosu/core/relay/FakeRelayPool.kt
@@ -23,7 +23,11 @@ class FakeRelayPool : RelayPool {
   /** Recorded calls to publishEvent */
   val publishCallArgs = mutableListOf<PublishCall>()
 
-  data class SubscribeCall(val relays: List<RelayConfig>, val filter: String, val timeoutMs: Long)
+  data class SubscribeCall(
+      val relays: List<RelayConfig>,
+      val filters: List<String>,
+      val timeoutMs: Long
+  )
 
   data class PublishCall(
       val relays: List<RelayConfig>,
@@ -33,10 +37,10 @@ class FakeRelayPool : RelayPool {
 
   override suspend fun subscribeWithTimeout(
       relays: List<RelayConfig>,
-      filter: String,
+      filters: List<String>,
       timeoutMs: Long
   ): List<NostrEvent> {
-    subscribeCallArgs.add(SubscribeCall(relays, filter, timeoutMs))
+    subscribeCallArgs.add(SubscribeCall(relays, filters, timeoutMs))
     return eventsToReturn
   }
 


### PR DESCRIPTION
## Summary

Change `RelayPool.subscribeWithTimeout` to accept a list of filters and send each as its own element of the REQ message.

## Details

`RelayCommentRepository` joined two filters with a comma so they would land as separate REQ elements, relying on `RelayPool` interpolating the string verbatim into the message.

Moving the multi-filter handling into `RelayPool` makes the REQ assembly an implementation detail again and frees callers from that coupling, as suggested in the PR 615 review.

The REQ bytes are unchanged.

## Confirmation

Ran `devbox run fmt`, detekt, and the full unit test suite locally; all green.

Added tests pinning that each filter is sent as its own REQ element and that an empty filter list returns no events.

## Limitation

No known limitations.

https://claude.ai/code/session_01JZj2XtqZ82ia8ygahd2j6u