### PR TITLE
fix: sync bookmark tab indicator with swipe gesture

### DIFF
--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
@@ -1,9 +1,14 @@
 package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
@@ -133,5 +138,34 @@ class BookmarkScreenSwipeTest {
         draggedLeft > restingLeft,
         "Tab indicator should move toward the Global tab while the swipe is in progress " +
             "(resting left: $restingLeft, dragged left: $draggedLeft)")
+  }
+
+  @Test
+  fun indicatorRestsUnderGlobalTabAfterCompletedSwipe() {
+    composeTestRule.setContent {
+      var selectedTab by remember { mutableStateOf(BookmarkFilterMode.Local) }
+      BookmarkScreen(
+          uiState =
+              BookmarkUiState(
+                  local = BookmarkTabState(items = listOf(localBookmark)),
+                  global = BookmarkTabState(items = listOf(globalBookmark)),
+                  selectedTab = selectedTab),
+          onRefresh = {},
+          onLoad = {},
+          onTabSelected = { tab -> selectedTab = tab })
+    }
+
+    composeTestRule.onRoot().performTouchInput { swipeLeft() }
+    composeTestRule.waitForIdle()
+
+    val indicatorBounds =
+        composeTestRule.onNodeWithTag("tabIndicator", useUnmergedTree = true).getBoundsInRoot()
+    val globalTabBounds = composeTestRule.onNodeWithText("Global").getBoundsInRoot()
+    val indicatorCenter = (indicatorBounds.left + indicatorBounds.right) / 2
+
+    assertTrue(
+        indicatorCenter > globalTabBounds.left && indicatorCenter < globalTabBounds.right,
+        "Tab indicator should rest under the Global tab after a completed swipe " +
+            "(indicator center: $indicatorCenter, Global tab: $globalTabBounds)")
   }
 }

--- a/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
+++ b/app/src/androidTest/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreenSwipeTest.kt
@@ -1,6 +1,9 @@
 package io.github.omochice.pinosu.feature.bookmark.presentation.ui
 
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
@@ -12,6 +15,7 @@ import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.Bookmar
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.junit.Rule
 
 /** Compose UI tests for swipe gesture tab switching on bookmark screen */
@@ -97,5 +101,37 @@ class BookmarkScreenSwipeTest {
         BookmarkFilterMode.Local,
         selectedTab,
         "Swiping right from Global tab should select Local tab")
+  }
+
+  @Test
+  fun indicatorFollowsSwipeGestureInProgress() {
+    composeTestRule.setContent {
+      BookmarkScreen(
+          uiState =
+              BookmarkUiState(
+                  local = BookmarkTabState(items = listOf(localBookmark)),
+                  global = BookmarkTabState(items = listOf(globalBookmark)),
+                  selectedTab = BookmarkFilterMode.Local),
+          onRefresh = {},
+          onLoad = {})
+    }
+
+    val restingLeft =
+        composeTestRule.onNodeWithTag("tabIndicator", useUnmergedTree = true).getBoundsInRoot().left
+
+    composeTestRule.onRoot().performTouchInput {
+      down(center)
+      repeat(4) { moveBy(Offset(-width / 16f, 0f)) }
+    }
+    composeTestRule.waitForIdle()
+
+    val draggedLeft =
+        composeTestRule.onNodeWithTag("tabIndicator", useUnmergedTree = true).getBoundsInRoot().left
+    composeTestRule.onRoot().performTouchInput { up() }
+
+    assertTrue(
+        draggedLeft > restingLeft,
+        "Tab indicator should move toward the Global tab while the swipe is in progress " +
+            "(resting left: $restingLeft, dragged left: $draggedLeft)")
   }
 }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
+import androidx.compose.material3.TabIndicatorScope
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -222,41 +223,7 @@ private fun BookmarkTopBar(
         })
     val selectedTabIndex = if (selectedTab == BookmarkFilterMode.Local) 0 else 1
     PrimaryTabRow(
-        selectedTabIndex = selectedTabIndex,
-        indicator = {
-          // The default tabIndicatorOffset animates only after the pager settles; deriving the
-          // position from the pager's scroll offset keeps the indicator under the finger during
-          // a swipe.
-          TabRowDefaults.PrimaryIndicator(
-              modifier =
-                  Modifier.tabIndicatorLayout { measurable, constraints, tabPositions ->
-                        val progress = pagerState.currentPage + pagerState.currentPageOffsetFraction
-                        val fromTab =
-                            tabPositions[
-                                floor(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
-                        val toTab =
-                            tabPositions[ceil(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
-                        val fraction = progress - floor(progress)
-                        val indicatorWidth =
-                            lerp(fromTab.contentWidth, toTab.contentWidth, fraction)
-                        val indicatorCenter =
-                            lerp(
-                                fromTab.left + fromTab.width / 2,
-                                toTab.left + toTab.width / 2,
-                                fraction)
-                        val widthPx = indicatorWidth.roundToPx()
-                        val placeable =
-                            measurable.measure(
-                                constraints.copy(minWidth = widthPx, maxWidth = widthPx))
-                        // The tab row bottom-aligns the indicator using the reported height, so the
-                        // layout must not stretch to the full row height.
-                        layout(constraints.maxWidth, placeable.height) {
-                          placeable.place(indicatorCenter.roundToPx() - widthPx / 2, 0)
-                        }
-                      }
-                      .testTag("tabIndicator"),
-              width = Dp.Unspecified)
-        }) {
+        selectedTabIndex = selectedTabIndex, indicator = { PagerSyncedTabIndicator(pagerState) }) {
           Tab(
               selected = selectedTab == BookmarkFilterMode.Local,
               onClick = { onTabSelected(BookmarkFilterMode.Local) },
@@ -267,6 +234,35 @@ private fun BookmarkTopBar(
               text = { Text(stringResource(R.string.tab_global)) })
         }
   }
+}
+
+// The default tabIndicatorOffset animates only after the pager settles; deriving the position
+// from the pager's scroll offset keeps the indicator under the finger during a swipe.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TabIndicatorScope.PagerSyncedTabIndicator(pagerState: PagerState) {
+  TabRowDefaults.PrimaryIndicator(
+      modifier =
+          Modifier.tabIndicatorLayout { measurable, constraints, tabPositions ->
+                val progress = pagerState.currentPage + pagerState.currentPageOffsetFraction
+                val fromTab =
+                    tabPositions[floor(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
+                val toTab = tabPositions[ceil(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
+                val fraction = progress - floor(progress)
+                val indicatorWidth = lerp(fromTab.contentWidth, toTab.contentWidth, fraction)
+                val indicatorCenter =
+                    lerp(fromTab.left + fromTab.width / 2, toTab.left + toTab.width / 2, fraction)
+                val widthPx = indicatorWidth.roundToPx()
+                val placeable =
+                    measurable.measure(constraints.copy(minWidth = widthPx, maxWidth = widthPx))
+                // The tab row bottom-aligns the indicator using the reported height, so the layout
+                // must not stretch to the full row height.
+                layout(constraints.maxWidth, placeable.height) {
+                  placeable.place(indicatorCenter.roundToPx() - widthPx / 2, 0)
+                }
+              }
+              .testTag("tabIndicator"),
+      width = Dp.Unspecified)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.core.nip.nip19.Nip19EventEncoder
 import io.github.omochice.pinosu.feature.bookmark.domain.model.BookmarkDisplayMode
@@ -57,6 +58,8 @@ import io.github.omochice.pinosu.feature.bookmark.domain.model.dTag
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkFilterMode
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkTabState
 import io.github.omochice.pinosu.feature.bookmark.presentation.viewmodel.BookmarkUiState
+import kotlin.math.ceil
+import kotlin.math.floor
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 private val sharedEncoder = Nip19EventEncoder()
@@ -137,6 +140,7 @@ fun BookmarkScreen(
       topBar = {
         BookmarkTopBar(
             selectedTab = uiState.selectedTab,
+            pagerState = pagerState,
             onOpenDrawer = onOpenDrawer,
             onTabSelected = onTabSelected)
       },
@@ -202,6 +206,7 @@ private fun BookmarkPager(
 @Composable
 private fun BookmarkTopBar(
     selectedTab: BookmarkFilterMode,
+    pagerState: PagerState,
     onOpenDrawer: () -> Unit,
     onTabSelected: (BookmarkFilterMode) -> Unit,
 ) {
@@ -219,10 +224,37 @@ private fun BookmarkTopBar(
     PrimaryTabRow(
         selectedTabIndex = selectedTabIndex,
         indicator = {
+          // The default tabIndicatorOffset animates only after the pager settles; deriving the
+          // position from the pager's scroll offset keeps the indicator under the finger during
+          // a swipe.
           TabRowDefaults.PrimaryIndicator(
               modifier =
-                  Modifier.testTag("tabIndicator")
-                      .tabIndicatorOffset(selectedTabIndex, matchContentSize = true),
+                  Modifier.tabIndicatorLayout { measurable, constraints, tabPositions ->
+                        val progress = pagerState.currentPage + pagerState.currentPageOffsetFraction
+                        val fromTab =
+                            tabPositions[
+                                floor(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
+                        val toTab =
+                            tabPositions[ceil(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
+                        val fraction = progress - floor(progress)
+                        val indicatorWidth =
+                            lerp(fromTab.contentWidth, toTab.contentWidth, fraction)
+                        val indicatorCenter =
+                            lerp(
+                                fromTab.left + fromTab.width / 2,
+                                toTab.left + toTab.width / 2,
+                                fraction)
+                        val widthPx = indicatorWidth.roundToPx()
+                        val placeable =
+                            measurable.measure(
+                                constraints.copy(minWidth = widthPx, maxWidth = widthPx))
+                        // The tab row bottom-aligns the indicator using the reported height, so the
+                        // layout must not stretch to the full row height.
+                        layout(constraints.maxWidth, placeable.height) {
+                          placeable.place(indicatorCenter.roundToPx() - widthPx / 2, 0)
+                        }
+                      }
+                      .testTag("tabIndicator"),
               width = Dp.Unspecified)
         }) {
           Tab(

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -244,21 +244,28 @@ private fun TabIndicatorScope.PagerSyncedTabIndicator(pagerState: PagerState) {
   TabRowDefaults.PrimaryIndicator(
       modifier =
           Modifier.tabIndicatorLayout { measurable, constraints, tabPositions ->
-                val progress = pagerState.currentPage + pagerState.currentPageOffsetFraction
-                val fromTab =
-                    tabPositions[floor(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
-                val toTab = tabPositions[ceil(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
-                val fraction = progress - floor(progress)
-                val indicatorWidth = lerp(fromTab.contentWidth, toTab.contentWidth, fraction)
-                val indicatorCenter =
-                    lerp(fromTab.left + fromTab.width / 2, toTab.left + toTab.width / 2, fraction)
-                val widthPx = indicatorWidth.roundToPx()
-                val placeable =
-                    measurable.measure(constraints.copy(minWidth = widthPx, maxWidth = widthPx))
-                // The tab row bottom-aligns the indicator using the reported height, so the layout
-                // must not stretch to the full row height.
-                layout(constraints.maxWidth, placeable.height) {
-                  placeable.place(indicatorCenter.roundToPx() - widthPx / 2, 0)
+                // The default tabIndicatorOffset guards against an empty position list, so mirror
+                // it here rather than let coerceIn throw on an empty index range.
+                if (tabPositions.isEmpty()) {
+                  layout(0, 0) {}
+                } else {
+                  val progress = pagerState.currentPage + pagerState.currentPageOffsetFraction
+                  val fromTab =
+                      tabPositions[floor(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
+                  val toTab =
+                      tabPositions[ceil(progress).toInt().coerceIn(0, tabPositions.lastIndex)]
+                  val fraction = progress - floor(progress)
+                  val indicatorWidth = lerp(fromTab.contentWidth, toTab.contentWidth, fraction)
+                  val indicatorCenter =
+                      lerp(fromTab.left + fromTab.width / 2, toTab.left + toTab.width / 2, fraction)
+                  val widthPx = indicatorWidth.roundToPx()
+                  val placeable =
+                      measurable.measure(constraints.copy(minWidth = widthPx, maxWidth = widthPx))
+                  // The tab row bottom-aligns the indicator using the reported height, so the
+                  // layout must not stretch to the full row height.
+                  layout(constraints.maxWidth, placeable.height) {
+                    placeable.place(indicatorCenter.roundToPx() - widthPx / 2, 0)
+                  }
                 }
               }
               .testTag("tabIndicator"),

--- a/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/bookmark/presentation/ui/BookmarkScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -29,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -41,8 +43,10 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.github.omochice.pinosu.R
 import io.github.omochice.pinosu.core.nip.nip19.Nip19EventEncoder
@@ -124,6 +128,11 @@ fun BookmarkScreen(
           onLoadMore = onLoadMore,
       )
 
+  val pagerState =
+      rememberPagerState(
+          initialPage = BookmarkFilterMode.entries.indexOf(uiState.selectedTab),
+          pageCount = { BookmarkFilterMode.entries.size })
+
   Scaffold(
       topBar = {
         BookmarkTopBar(
@@ -142,6 +151,7 @@ fun BookmarkScreen(
       }) { paddingValues ->
         BookmarkPager(
             uiState = uiState,
+            pagerState = pagerState,
             onTabSelected = onTabSelected,
             onLoad = onLoad,
             callbacks = callbacks,
@@ -152,16 +162,12 @@ fun BookmarkScreen(
 @Composable
 private fun BookmarkPager(
     uiState: BookmarkUiState,
+    pagerState: PagerState,
     onTabSelected: (BookmarkFilterMode) -> Unit,
     onLoad: (BookmarkFilterMode) -> Unit,
     callbacks: BookmarkListCallbacks,
     modifier: Modifier = Modifier,
 ) {
-  val pagerState =
-      rememberPagerState(
-          initialPage = BookmarkFilterMode.entries.indexOf(uiState.selectedTab),
-          pageCount = { BookmarkFilterMode.entries.size })
-
   LaunchedEffect(uiState.selectedTab) {
     val targetPage = BookmarkFilterMode.entries.indexOf(uiState.selectedTab)
     if (pagerState.currentPage != targetPage) {
@@ -209,16 +215,25 @@ private fun BookmarkTopBar(
                 contentDescription = stringResource(R.string.cd_open_menu))
           }
         })
-    PrimaryTabRow(selectedTabIndex = if (selectedTab == BookmarkFilterMode.Local) 0 else 1) {
-      Tab(
-          selected = selectedTab == BookmarkFilterMode.Local,
-          onClick = { onTabSelected(BookmarkFilterMode.Local) },
-          text = { Text(stringResource(R.string.tab_local)) })
-      Tab(
-          selected = selectedTab == BookmarkFilterMode.Global,
-          onClick = { onTabSelected(BookmarkFilterMode.Global) },
-          text = { Text(stringResource(R.string.tab_global)) })
-    }
+    val selectedTabIndex = if (selectedTab == BookmarkFilterMode.Local) 0 else 1
+    PrimaryTabRow(
+        selectedTabIndex = selectedTabIndex,
+        indicator = {
+          TabRowDefaults.PrimaryIndicator(
+              modifier =
+                  Modifier.testTag("tabIndicator")
+                      .tabIndicatorOffset(selectedTabIndex, matchContentSize = true),
+              width = Dp.Unspecified)
+        }) {
+          Tab(
+              selected = selectedTab == BookmarkFilterMode.Local,
+              onClick = { onTabSelected(BookmarkFilterMode.Local) },
+              text = { Text(stringResource(R.string.tab_local)) })
+          Tab(
+              selected = selectedTab == BookmarkFilterMode.Global,
+              onClick = { onTabSelected(BookmarkFilterMode.Global) },
+              text = { Text(stringResource(R.string.tab_global)) })
+        }
   }
 }
 


### PR DESCRIPTION
## Summary

Sync the bookmark tab indicator with the pager's swipe offset so it follows the finger during a swipe instead of jumping after the page settles.

## Details

The default Material3 indicator animates only after the pager settles, so the indicator stayed still while a swipe was in progress.

Deriving the indicator position from the pager's current page and scroll offset fraction inside a custom `tabIndicatorLayout` keeps the indicator under the finger, and reading the state in the layout phase makes swiping trigger re-layout only, not recomposition.

## Confirmation

Ran `devbox run ./gradlew detekt test connectedAndroidTest` on a local API 34 emulator and everything passed, including two new instrumented tests that pin the mid-swipe tracking and the resting position after a completed swipe.

## Limitation

Tab text emphasis still switches only after the page settles, since the selected-tab state remains ViewModel-driven.

https://claude.ai/code/session_01JZj2XtqZ82ia8ygahd2j6u