### PR TITLE
fix: restore login with signer apps that return hex pubkeys

### DIFF
--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClient.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClient.kt
@@ -199,7 +199,8 @@ data class SignedEventResponse(val signedEventJson: String)
 /**
  * Response from NIP-55 signer
  *
- * @property pubkey User's public key (64-character hex string)
+ * @property pubkey User's public key, always Bech32-encoded (npub1...) regardless of the encoding
+ *   the signer replied with
  * @property packageName NIP-55 signer app package name
  */
 data class Nip55Response(val pubkey: String, val packageName: String)

--- a/app/src/main/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClient.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClient.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.util.Log
 import androidx.core.net.toUri
+import com.vitorpamplona.quartz.nip19Bech32.entities.NPub
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.omochice.pinosu.core.model.Pubkey
 import javax.inject.Inject
@@ -66,13 +67,32 @@ constructor(@param:ApplicationContext private val context: Context) {
       return Result.failure(Nip55Error.InvalidResponse("Result is null or empty"))
     }
 
-    if (!Pubkey.isValidFormat(pubkey)) {
+    val npub = normalizeToNpub(pubkey)
+    if (npub == null) {
       return Result.failure(
-          Nip55Error.InvalidResponse("Invalid pubkey format: must be Bech32-encoded (npub1...)"))
+          Nip55Error.InvalidResponse(
+              "Invalid pubkey format: must be Bech32-encoded (npub1...) or 64-character hex"))
     }
 
-    return Result.success(Nip55Response(pubkey, NIP55_SIGNER_PACKAGE_NAME))
+    return Result.success(Nip55Response(npub, NIP55_SIGNER_PACKAGE_NAME))
   }
+
+  /**
+   * Normalize a pubkey returned by a NIP-55 signer to Bech32 form
+   *
+   * NIP-55 states that all pubkeys in the protocol are hex, and Amber 6.3.0 returns hex from
+   * get_public_key, but older builds returned npub to package callers. Both encodings are accepted
+   * so the app works across signer versions.
+   *
+   * @param pubkey Pubkey string as received from the signer
+   * @return npub form of the pubkey, or null if it is neither an npub nor a 64-character hex string
+   */
+  private fun normalizeToNpub(pubkey: String): String? =
+      when {
+        Pubkey.isValidFormat(pubkey) -> pubkey
+        HEX_PUBKEY_PATTERN.matches(pubkey) -> NPub.create(pubkey.lowercase())
+        else -> null
+      }
 
   /**
    * Mask sensitive pubkey for logging
@@ -160,6 +180,7 @@ constructor(@param:ApplicationContext private val context: Context) {
 
   companion object {
     private const val TAG = "Nip55SignerClient"
+    private val HEX_PUBKEY_PATTERN = Regex("[0-9a-fA-F]{64}")
     const val NIP55_SIGNER_PACKAGE_NAME = "com.greenart7c3.nostrsigner"
     const val NOSTRSIGNER_SCHEME = "nostrsigner"
     const val TYPE_GET_PUBLIC_KEY = "get_public_key"

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/data/repository/Nip55AuthRepository.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/data/repository/Nip55AuthRepository.kt
@@ -86,7 +86,8 @@ constructor(
       val nip55Response = nip55Result.getOrNull()!!
       val pubkey =
           Pubkey.parse(nip55Response.pubkey)
-              ?: return Result.failure(LoginError.NetworkError("Invalid pubkey format from signer"))
+              ?: return Result.failure(
+                  LoginError.InvalidSignerResponse("Invalid pubkey format from signer"))
       val user = User(pubkey)
 
       try {
@@ -102,7 +103,7 @@ constructor(
             is Nip55Error.NotInstalled -> LoginError.Nip55SignerNotInstalled
             is Nip55Error.UserRejected -> LoginError.UserRejected
             is Nip55Error.Timeout -> LoginError.Timeout
-            is Nip55Error.InvalidResponse -> LoginError.NetworkError(nip55Error.message)
+            is Nip55Error.InvalidResponse -> LoginError.InvalidSignerResponse(nip55Error.message)
             is Nip55Error.IntentResolutionError -> LoginError.NetworkError(nip55Error.message)
             null -> LoginError.UnknownError(Exception("Unknown NIP-55 signer error"))
           }

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/model/error/ErrorTypes.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/domain/model/error/ErrorTypes.kt
@@ -27,6 +27,16 @@ sealed class LoginError : Exception() {
   data object InvalidPubkey : LoginError()
 
   /**
+   * NIP-55 signer returned a response the app could not read
+   *
+   * Distinct from [NetworkError] because no network call is involved: the signer replied, but its
+   * payload was missing or in an unexpected encoding.
+   *
+   * @property message Error message
+   */
+  data class InvalidSignerResponse(override val message: String) : LoginError()
+
+  /**
    * Unknown error occurred
    *
    * @property throwable The exception that occurred

--- a/app/src/main/java/io/github/omochice/pinosu/feature/auth/presentation/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/io/github/omochice/pinosu/feature/auth/presentation/viewmodel/LoginViewModel.kt
@@ -150,6 +150,9 @@ constructor(
               is LoginError.NetworkError ->
                   LoginUiState.Error.Retryable(
                       "A network error occurred. Please check your connection.")
+              is LoginError.InvalidSignerResponse ->
+                  LoginUiState.Error.Retryable(
+                      "Could not read the response from the signer app. Please try again.")
               is LoginError.UnknownError -> LoginUiState.Error.NonRetryable(ERROR_GENERIC)
               else -> LoginUiState.Error.NonRetryable(ERROR_GENERIC)
             }

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClientTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClientTest.kt
@@ -158,6 +158,22 @@ class Nip55SignerClientTest {
   }
 
   @Test
+  fun `handleNip55Response with uppercase hex result should return the matching npub`() {
+    val hexPubkey = "82341F882B6EABCD2BA7F1EF90AAD961CF074AF15B9EF44A09F9D2A8FBFBE6A2"
+    val expectedNpub = "npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m"
+    val intent = android.content.Intent()
+    intent.putExtra("result", hexPubkey)
+
+    val result = nip55SignerClient.handleNip55Response(android.app.Activity.RESULT_OK, intent)
+
+    assertTrue(result.isSuccess, "Should return success")
+    assertEquals(
+        expectedNpub,
+        result.getOrNull()?.pubkey,
+        "Hex casing should not decide whether login works")
+  }
+
+  @Test
   fun `handleNip55Response when user rejected should return error`() {
     val intent = android.content.Intent()
     intent.putExtra("rejected", true)

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClientTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClientTest.kt
@@ -144,6 +144,20 @@ class Nip55SignerClientTest {
   }
 
   @Test
+  fun `handleNip55Response with hex result should return the matching npub`() {
+    val hexPubkey = "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"
+    val expectedNpub = "npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m"
+    val intent = android.content.Intent()
+    intent.putExtra("result", hexPubkey)
+
+    val result = nip55SignerClient.handleNip55Response(android.app.Activity.RESULT_OK, intent)
+
+    assertTrue(result.isSuccess, "Should return success")
+    assertEquals(
+        expectedNpub, result.getOrNull()?.pubkey, "Hex pubkey should be normalized to npub")
+  }
+
+  @Test
   fun `handleNip55Response when user rejected should return error`() {
     val intent = android.content.Intent()
     intent.putExtra("rejected", true)

--- a/app/src/test/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClientTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/core/nip/nip55/Nip55SignerClientTest.kt
@@ -198,7 +198,7 @@ class Nip55SignerClientTest {
   @Test
   fun `handleNip55Response with invalid pubkey length should return InvalidResponse`() {
     val intent = android.content.Intent()
-    intent.putExtra("result", "a".repeat(64))
+    intent.putExtra("result", "a".repeat(63))
 
     val result = nip55SignerClient.handleNip55Response(android.app.Activity.RESULT_OK, intent)
 

--- a/app/src/test/java/io/github/omochice/pinosu/feature/auth/data/repository/Nip55AuthRepositoryTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/auth/data/repository/Nip55AuthRepositoryTest.kt
@@ -226,7 +226,7 @@ class Nip55AuthRepositoryTest {
   }
 
   @Test
-  fun `processNip55Response on InvalidResponse should return NetworkError`() = runTest {
+  fun `processNip55Response on InvalidResponse should return InvalidSignerResponse`() = runTest {
     val intent = Intent()
     every { nip55SignerClient.handleNip55Response(any(), any()) } returns
         Result.failure(
@@ -236,7 +236,9 @@ class Nip55AuthRepositoryTest {
 
     assertTrue(result.isFailure, "Should return failure")
     val exception = result.exceptionOrNull()
-    assertTrue(exception is LoginError.NetworkError, "Exception should be LoginError.NetworkError")
+    assertTrue(
+        exception is LoginError.InvalidSignerResponse,
+        "Exception should be LoginError.InvalidSignerResponse but was $exception")
   }
 
   @Test

--- a/app/src/test/java/io/github/omochice/pinosu/feature/auth/domain/model/error/ErrorTypesTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/auth/domain/model/error/ErrorTypesTest.kt
@@ -67,6 +67,7 @@ class ErrorTypesTest {
             LoginError.Timeout,
             LoginError.NetworkError("test"),
             LoginError.InvalidPubkey,
+            LoginError.InvalidSignerResponse("test"),
             LoginError.UnknownError(RuntimeException()))
 
     errors.forEach { error ->
@@ -77,6 +78,7 @@ class ErrorTypesTest {
             is LoginError.Timeout -> "timeout"
             is LoginError.NetworkError -> "network_error"
             is LoginError.InvalidPubkey -> "invalid_pubkey"
+            is LoginError.InvalidSignerResponse -> "invalid_signer_response"
             is LoginError.UnknownError -> "unknown_error"
           }
 

--- a/app/src/test/java/io/github/omochice/pinosu/feature/auth/integration/Nip55LoginIntegrationTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/auth/integration/Nip55LoginIntegrationTest.kt
@@ -20,7 +20,6 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -112,18 +111,17 @@ class Nip55LoginIntegrationTest {
   }
 
   @Test
-  fun `an unreadable signer response does not blame the network`() = runTest {
+  fun `an unreadable signer response offers a retry and names the signer`() = runTest {
     val response = Intent().putExtra("result", "not-a-pubkey")
 
     viewModel.processNip55Response(Activity.RESULT_OK, response)
     advanceUntilIdle()
 
-    val state = viewModel.uiState.value
-    assertTrue(state is LoginUiState.Error, "state should be an error but was $state")
-    assertFalse(
-        state.message.contains("network", ignoreCase = true) ||
-            state.message.contains("connection", ignoreCase = true),
-        "message should not blame the network but was \"${state.message}\"")
+    assertEquals(
+        LoginUiState.Error.Retryable(
+            "Could not read the response from the signer app. Please try again."),
+        viewModel.uiState.value,
+        "the signer response error should stay retryable and point at the signer, not the network")
   }
 
   companion object {

--- a/app/src/test/java/io/github/omochice/pinosu/feature/auth/integration/Nip55LoginIntegrationTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/auth/integration/Nip55LoginIntegrationTest.kt
@@ -19,6 +19,7 @@ import io.mockk.mockk
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -95,11 +96,26 @@ class Nip55LoginIntegrationTest {
     assertTrue(state is LoginUiState.Success, "state should be Success but was $state")
   }
 
+  @Test
+  fun `hex and npub responses log in the same account`() = runTest {
+    viewModel.processNip55Response(Activity.RESULT_OK, Intent().putExtra("result", TEST_VALID_HEX))
+    advanceUntilIdle()
+    val fromHex = viewModel.mainUiState.value.userPubkey
+
+    viewModel.processNip55Response(Activity.RESULT_OK, Intent().putExtra("result", TEST_VALID_NPUB))
+    advanceUntilIdle()
+    val fromNpub = viewModel.mainUiState.value.userPubkey
+
+    assertEquals(TEST_VALID_NPUB, fromHex, "hex response should resolve to the matching npub")
+    assertEquals(fromNpub, fromHex, "both encodings should log in the same account")
+  }
+
   companion object {
     /**
-     * Well-known Nostr public key (fiatjaf) in hex form, which is what Amber 6.3.0 returns from
-     * get_public_key.
+     * Well-known Nostr public key (fiatjaf) in the two encodings a NIP-55 signer may return. Amber
+     * 6.3.0 returns the hex form from get_public_key.
      */
     const val TEST_VALID_HEX = "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"
+    const val TEST_VALID_NPUB = "npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m"
   }
 }

--- a/app/src/test/java/io/github/omochice/pinosu/feature/auth/integration/Nip55LoginIntegrationTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/auth/integration/Nip55LoginIntegrationTest.kt
@@ -1,0 +1,105 @@
+package io.github.omochice.pinosu.feature.auth.integration
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import io.github.omochice.pinosu.core.nip.nip55.Nip55SignerClient
+import io.github.omochice.pinosu.feature.auth.data.local.LocalAuthDataSource
+import io.github.omochice.pinosu.feature.auth.data.repository.Nip55AuthRepository
+import io.github.omochice.pinosu.feature.auth.domain.repository.AuthRepository
+import io.github.omochice.pinosu.feature.auth.domain.usecase.FetchRelayListUseCase
+import io.github.omochice.pinosu.feature.auth.domain.usecase.Nip55GetLoginStateUseCase
+import io.github.omochice.pinosu.feature.auth.domain.usecase.Nip55LoginUseCase
+import io.github.omochice.pinosu.feature.auth.domain.usecase.Nip55LogoutUseCase
+import io.github.omochice.pinosu.feature.auth.domain.usecase.ReadOnlyLoginUseCase
+import io.github.omochice.pinosu.feature.auth.presentation.viewmodel.LoginUiState
+import io.github.omochice.pinosu.feature.auth.presentation.viewmodel.LoginViewModel
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Integration tests for the NIP-55 login path, from the signer's ActivityResult to the login UI
+ * state.
+ *
+ * Test strategy:
+ * - Presentation layer: actual LoginViewModel
+ * - Domain layer: actual UseCases
+ * - Data layer: actual Nip55SignerClient and Nip55AuthRepository, mocked LocalAuthDataSource
+ *
+ * The repository is real here on purpose: mocking it would bypass the decoding of the signer's
+ * response, which is the behavior under test. Robolectric supplies a working Intent and the Bech32
+ * encoder used to normalize the pubkey.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class Nip55LoginIntegrationTest {
+
+  private lateinit var localAuthDataSource: LocalAuthDataSource
+  private lateinit var authRepository: AuthRepository
+  private lateinit var fetchRelayListUseCase: FetchRelayListUseCase
+  private lateinit var viewModel: LoginViewModel
+
+  private val testDispatcher = StandardTestDispatcher()
+
+  @BeforeTest
+  fun setup() {
+    Dispatchers.setMain(testDispatcher)
+
+    val context = mockk<Context>(relaxed = true)
+    val signerClient = Nip55SignerClient(context)
+
+    localAuthDataSource = mockk(relaxed = true)
+    fetchRelayListUseCase = mockk()
+    coEvery { fetchRelayListUseCase(any()) } returns Result.success(emptyList())
+
+    authRepository = Nip55AuthRepository(signerClient, localAuthDataSource)
+
+    viewModel =
+        LoginViewModel(
+            Nip55LoginUseCase(authRepository),
+            Nip55LogoutUseCase(authRepository),
+            Nip55GetLoginStateUseCase(authRepository),
+            authRepository,
+            fetchRelayListUseCase,
+            mockk<ReadOnlyLoginUseCase>(relaxed = true))
+  }
+
+  @AfterTest
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun `login succeeds when signer returns a hex pubkey`() = runTest {
+    val response = Intent().putExtra("result", TEST_VALID_HEX)
+
+    viewModel.processNip55Response(Activity.RESULT_OK, response)
+    advanceUntilIdle()
+
+    val state = viewModel.uiState.value
+    assertTrue(state is LoginUiState.Success, "state should be Success but was $state")
+  }
+
+  companion object {
+    /**
+     * Well-known Nostr public key (fiatjaf) in hex form, which is what Amber 6.3.0 returns from
+     * get_public_key.
+     */
+    const val TEST_VALID_HEX = "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"
+  }
+}

--- a/app/src/test/java/io/github/omochice/pinosu/feature/auth/integration/Nip55LoginIntegrationTest.kt
+++ b/app/src/test/java/io/github/omochice/pinosu/feature/auth/integration/Nip55LoginIntegrationTest.kt
@@ -20,6 +20,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -108,6 +109,21 @@ class Nip55LoginIntegrationTest {
 
     assertEquals(TEST_VALID_NPUB, fromHex, "hex response should resolve to the matching npub")
     assertEquals(fromNpub, fromHex, "both encodings should log in the same account")
+  }
+
+  @Test
+  fun `an unreadable signer response does not blame the network`() = runTest {
+    val response = Intent().putExtra("result", "not-a-pubkey")
+
+    viewModel.processNip55Response(Activity.RESULT_OK, response)
+    advanceUntilIdle()
+
+    val state = viewModel.uiState.value
+    assertTrue(state is LoginUiState.Error, "state should be an error but was $state")
+    assertFalse(
+        state.message.contains("network", ignoreCase = true) ||
+            state.message.contains("connection", ignoreCase = true),
+        "message should not blame the network but was \"${state.message}\"")
   }
 
   companion object {


### PR DESCRIPTION
## Summary

Accept the hex pubkey that current NIP-55 signers return, so login works again.

## Details

Amber 6.3.0 returns hex from `get_public_key`, but the handler accepted `npub1...` only and reported the rejection as `LoginError.NetworkError`, which sent users to check a connection that was never involved.

Hex is normalized at the NIP-55 boundary, so `Pubkey` stays npub-only and read-only login is untouched. A malformed response now maps to `LoginError.InvalidSignerResponse`.

## Confirmation

`devbox run ./gradlew detekt test` passes, and the reproduction test fails on the pre-fix code with the exact message seen on the device.

## Limitation

Not verified on a device. The evidence is a logcat capture plus Amber v6.3.0 source.

https://claude.ai/code/session_01K9mkzdVDXdpQeTkCpoyTcC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NIP-55 login now accepts both hexadecimal and Bech32 public keys.
  * Hexadecimal keys are normalized consistently to Bech32 format.
  * Invalid signer responses are reported as signer-response errors instead of network failures.
  * Login errors now provide clearer, retryable feedback when signer data cannot be read.

* **Tests**
  * Expanded coverage for uppercase and lowercase hexadecimal keys, equivalent account resolution, and invalid signer responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->