### PR TITLE
chore: remove com.google.android.material

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,6 @@ android {
 
 dependencies {
   implementation(libs.androidx.core.ktx)
-  implementation(libs.material)
   val composeBom = platform(libs.androidx.compose.bom)
   implementation(composeBom)
   androidTestImplementation(composeBom)

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Base.Theme.Pinosu" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Base.Theme.Pinosu" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <!-- Customize your dark theme here. -->
         <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
     </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Base.Theme.Pinosu" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Base.Theme.Pinosu" parent="@android:style/Theme.DeviceDefault.Light.NoActionBar">
         <!-- Customize your light theme here. -->
         <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
     </style>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ junit = {group = "junit", name = "junit", version.ref = "junit"}
 androidx-junit = {group = "androidx.test.ext", name = "junit", version.ref = "junitVersion"}
 androidx-test-runner = {group = "androidx.test", name = "runner", version.ref = "testRunner"}
 androidx-test-espresso-core = {group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso"}
-material = {group = "com.google.android.material", name = "material", version.ref = "material"}
 androidx-navigation-compose = {group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose"}
 androidx-hilt-lifecycle-viewmodel-compose = {group = "androidx.hilt", name = "hilt-lifecycle-viewmodel-compose", version.ref = "hiltNavigationCompose"}
 androidx-compose-bom = {group = "androidx.compose", name = "compose-bom", version.ref = "composeBom"}
@@ -66,7 +65,6 @@ junit = "4.13.2"
 junitVersion = "1.3.0"
 testRunner = "1.7.0"
 espresso = "3.7.0"
-material = "1.14.0"
 navigationCompose = "2.9.8"
 hiltNavigationCompose = "1.4.0"
 composeBom = "2026.06.01"


### PR DESCRIPTION
## Summary

Remove the `com.google.android.material` dependency.

## Details

The library was reachable only through the XML theme parent, and nothing in the source referenced its classes, so the parent now points at the platform DeviceDefault themes instead.

DeviceDefault has no DayNight variant carrying `NoActionBar`, so the day and night qualifiers select the light and dark parents separately.

This also drops `androidx.appcompat` and `androidx.constraintlayout`, which entered the graph solely through it.

## Confirmation

`detekt test` and `connectedAndroidTest` passed (130 tests, 0 failures), and the debug build rendered as expected on an API 34 emulator in both light and dark mode.

## Limitation

DeviceDefault can be overridden by device manufacturers, so the window background may differ on physical devices.

https://claude.ai/code/session_01B8Z4JohZeXkzbEyvvhxoar