### PR TITLE
chore: drop the redundant aboutlibraries-core declaration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,7 +126,6 @@ dependencies {
   implementation(libs.coil.compose)
   implementation(libs.coil.network.okhttp)
 
-  implementation(libs.aboutlibraries.core)
   implementation(libs.aboutlibraries.compose.m3)
 
   implementation(libs.hilt.android)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,6 @@ robolectric = {group = "org.robolectric", name = "robolectric", version.ref = "r
 kotlinx-coroutines-android = {group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines"}
 kotlinx-coroutines-test = {group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines"}
 kotlinx-serialization-json = {group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serializationJson"}
-aboutlibraries-core = {group = "com.mikepenz", name = "aboutlibraries-core", version.ref = "aboutlibraries"}
 aboutlibraries-compose-m3 = {group = "com.mikepenz", name = "aboutlibraries-compose-m3", version.ref = "aboutlibraries"}
 androidx-datastore = {group = "androidx.datastore", name = "datastore", version.ref = "datastore"}
 tink-android = {group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink"}


### PR DESCRIPTION
## Summary

Drop the explicit `aboutlibraries-core` declaration.

## Details

Nothing in the app references a symbol that only core provides, since `LicenseScreen` uses `produceLibraries` and `LibrariesContainer` and both live in the compose artifacts.

Core stays on both classpaths regardless, because `LibrariesContainer` takes `Libs` and `entity.Library` in its public signature, so `aboutlibraries-compose-m3` has to expose it as an `api` dependency rather than an `implementation` one.

## Confirmation

`detekt test assembleDebug` passed, and the resolved `debugRuntimeClasspath` module set is identical before and after at 240 modules.

## Limitation

No known limitations.

https://claude.ai/code/session_01B8Z4JohZeXkzbEyvvhxoar